### PR TITLE
Adding a ToolFetcher class

### DIFF
--- a/server/mlabns/db/tool_fetcher.py
+++ b/server/mlabns/db/tool_fetcher.py
@@ -1,0 +1,149 @@
+import logging
+
+from google.appengine.api import memcache
+
+from mlabns.db import model
+from mlabns.util import constants
+from mlabns.util import message
+
+
+def _filter_by_status(tools, address_family, status):
+    """Filter sliver tools based on the status of their available interfaces.
+
+    Args:
+        tools: A list of sliver tools to filter by status.
+        address_family: Address family of the interface to which the status
+            parameter applies. If None, include tools that have the given
+            status on any interface.
+        status: Tool status to filter for (i.e. only return tools with this
+            status).
+
+    Returns:
+        A subset of the provided tools, filtered by status.
+    """
+    status_attrs = []
+    if address_family == message.ADDRESS_FAMILY_IPv4:
+        status_attrs.append('status_ipv4')
+    elif address_family == message.ADDRESS_FAMILY_IPv6:
+        status_attrs.append('status_ipv6')
+    else:
+        # When caller has not specified an address family, use any interface
+        status_attrs.append('status_ipv4')
+        status_attrs.append('status_ipv6')
+
+    filtered = []
+    for tool in tools:
+        for status_attr in status_attrs:
+            if getattr(tool, status_attr) == status:
+                filtered.append(tool)
+                # Exit as soon as the tool matches any set of criteria
+                break
+    return filtered
+
+
+def _find_site_ids_for_metro(metro):
+    """Determine which site IDs are present in a given metro.
+
+    Args:
+        metro: The metro for which to find site IDs.
+
+    Returns:
+        A list of site IDs for the given metro.
+    """
+    sites = model.Site.all().filter('metro =', metro).fetch(
+        constants.MAX_FETCHED_RESULTS)
+
+    if not sites:
+        logging.warning('No results found for metro %s.', metro)
+        return []
+
+    logging.info('Found %d results for metro %s.', len(sites), metro)
+    return [s.site_id for s in sites]
+
+
+class ToolProperties(object):
+    """A set of criteria to specify matching SliverTool(s)."""
+
+    def __init__(self, tool_id, status=None, address_family=None, metro=None,
+                 country=None):
+        self.tool_id = tool_id
+        self.status = status
+        self.address_family = address_family
+        self.metro = metro
+        self.country = country
+
+
+class ToolFetcher(object):
+    """Fetches SliverTools from AppEngine memcache and Datastore."""
+
+    def __init__(self):
+        self._memcache_fetcher = ToolFetcherMemcache()
+        self._datastore_fetcher = ToolFetcherDatastore()
+
+    def fetch(self, tool_properties):
+        """Fetch SliverTool objects with specified criteria.
+
+        Retrieves SliverTool objects with matching criteria. Tries to retrieve
+        from memcache first, but fails over to Datastore if memcache has no
+        matches.
+
+        Args:
+            tool_properties: A set of criteria that specifies what subset of
+                SliverTools to retrieve from the Datastore.
+
+        Returns:
+            A list of SliverTool objects that match the specified criteria.
+        """
+        results = self._memcache_fetcher.fetch(tool_properties)
+        if results:
+            return results
+
+        return self._datastore_fetcher.fetch(tool_properties)
+
+
+class ToolFetcherMemcache(object):
+
+    def fetch(self, tool_properties):
+        raise NotImplementedError()
+
+
+class ToolFetcherDatastore(object):
+    """Fetches SliverTool objects from the AppEngine Datastore."""
+
+    def fetch(self, tool_properties):
+        """Fetch SliverTool objects from the Datastore with specified criteria.
+
+        Args:
+            tool_properties: A set of criteria that specifies what subset of
+                SliverTools to retrieve from the Datastore.
+
+        Returns:
+            A list of SliverTool objects that match the specified criteria.
+        """
+        gql_clauses = ['tool_id = :tool_id']
+        if tool_properties.metro:
+            site_ids = _find_site_ids_for_metro(tool_properties.metro)
+            gql_clauses.append('site_id in :site_ids')
+        else:
+            site_ids = None
+        if tool_properties.country:
+            gql_clauses.append('country = :country')
+
+        gql = 'WHERE ' + ' AND '.join(gql_clauses)
+
+        gql_query = model.SliverTool.gql(
+            gql,
+            tool_id=tool_properties.tool_id,
+            status=tool_properties.status,
+            site_ids=site_ids,
+            country=tool_properties.country)
+        results = gql_query.fetch(constants.MAX_FETCHED_RESULTS)
+
+        # GQL doesn't have an OR operator, which makes it impossible to write
+        # GQL like (status_ipv4 = 'online' OR status_ipv6 = 'online') so we do
+        # status filtering in application code.
+        if tool_properties.status:
+            results = _filter_by_status(
+                results, tool_properties.address_family, tool_properties.status)
+
+        return results

--- a/server/mlabns/tests/test_tool_fetcher.py
+++ b/server/mlabns/tests/test_tool_fetcher.py
@@ -1,0 +1,255 @@
+import unittest
+
+from mlabns.db import model
+from mlabns.db import tool_fetcher
+from mlabns.util import message
+
+from google.appengine.ext import db
+from google.appengine.ext import testbed
+
+
+class ToolFetcherDatastoreTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.testbed = testbed.Testbed()
+        self.testbed.activate()
+        self.testbed.init_datastore_v3_stub()
+        self.fetcher = tool_fetcher.ToolFetcherDatastore()
+        self.db_root = db.Model(key_name='root')
+
+    def tearDown(self):
+        self.testbed.deactivate()
+
+    def assertSiteIdsEqual(self, site_ids_expected, tools_actual):
+        site_ids_actual = [t.site_id for t in tools_actual]
+        self.assertEqual(set(site_ids_expected), set(site_ids_actual))
+
+    def verifyPropertiesReturnExpectedSiteIds(self, site_ids_expected,
+                                              tool_properties):
+        self.assertSiteIdsEqual(site_ids_expected,
+                                self.fetcher.fetch(tool_properties))
+
+    def insertSliverTool(self, tool_id, site_id=None, status_ipv4=None,
+                         status_ipv6=None, latitude=None, longitude=None,
+                         country=None):
+        tool = model.SliverTool(parent=self.db_root.key())
+        tool.tool_id = tool_id
+        tool.site_id = site_id
+        tool.status_ipv4 = status_ipv4
+        tool.status_ipv6 = status_ipv6
+        tool.latitude = latitude
+        tool.longitude = longitude
+        tool.country = country
+        tool.put()
+
+    def insertSite(self, site_id):
+        site = model.Site(parent=self.db_root.key())
+        site.site_id = site_id
+        # Metro is always a 2-tuple where the first is the metro (first three
+        # letters of the site ID) and the second is the site ID itself.
+        site.metro = [site_id[:3], site_id]
+        site.put()
+
+    def initToolIdSiteGroup(self):
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='abc01', country='CountryA',
+            status_ipv4=message.STATUS_ONLINE,
+            status_ipv6=message.STATUS_ONLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_b', site_id='abc01', country='CountryA',
+            status_ipv4=message.STATUS_ONLINE,
+            status_ipv6=message.STATUS_ONLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_c', site_id='abc01', country='CountryA',
+            status_ipv4=message.STATUS_ONLINE,
+            status_ipv6=message.STATUS_ONLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='abc02', country='CountryA',
+            status_ipv4=message.STATUS_ONLINE,
+            status_ipv6=message.STATUS_OFFLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_b', site_id='abc02', country='CountryA',
+            status_ipv4=message.STATUS_OFFLINE,
+            status_ipv6=message.STATUS_OFFLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='abc03', country='CountryA',
+            status_ipv4=message.STATUS_OFFLINE,
+            status_ipv6=message.STATUS_OFFLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_c', site_id='abc03', country='CountryA',
+            status_ipv4=message.STATUS_OFFLINE,
+            status_ipv6=message.STATUS_OFFLINE)
+
+    def testFetchToolA(self):
+        self.initToolIdSiteGroup()
+        tool_properties = tool_fetcher.ToolProperties(tool_id='mock_tool_a')
+        self.verifyPropertiesReturnExpectedSiteIds(
+            ('abc01', 'abc02', 'abc03'), tool_properties)
+
+    def testFetchToolB(self):
+        self.initToolIdSiteGroup()
+        tool_properties = tool_fetcher.ToolProperties(tool_id='mock_tool_b')
+        self.verifyPropertiesReturnExpectedSiteIds(
+            ('abc01', 'abc02'), tool_properties)
+
+    def testFetchToolC(self):
+        self.initToolIdSiteGroup()
+        tool_properties = tool_fetcher.ToolProperties(tool_id='mock_tool_c')
+        self.verifyPropertiesReturnExpectedSiteIds(
+            ('abc01', 'abc03'), tool_properties)
+
+    def testFetchNonExistentTool(self):
+        self.initToolIdSiteGroup()
+        tool_properties = tool_fetcher.ToolProperties(tool_id='no_exist_tool')
+        self.verifyPropertiesReturnExpectedSiteIds([], tool_properties)
+
+    def init_status_site_group(self):
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='abc01', country='CountryA',
+            status_ipv4=message.STATUS_ONLINE,
+            status_ipv6=message.STATUS_ONLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='abc02', country='CountryA',
+            status_ipv4=message.STATUS_ONLINE,
+            status_ipv6=message.STATUS_OFFLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='abc03', country='CountryA',
+            status_ipv4=message.STATUS_OFFLINE,
+            status_ipv6=message.STATUS_OFFLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='xyz01', country='CountryB',
+            status_ipv4=message.STATUS_OFFLINE,
+            status_ipv6=message.STATUS_ONLINE)
+
+    def testFetchToolsWithAtLeastOneOnlineInterface(self):
+        self.init_status_site_group()
+        tool_properties = tool_fetcher.ToolProperties(
+            tool_id='mock_tool_a', status=message.STATUS_ONLINE)
+        self.verifyPropertiesReturnExpectedSiteIds(
+            ('abc01', 'abc02', 'xyz01'), tool_properties)
+
+    def testFetchToolsWithAtLeastOneOfflineInterface(self):
+        self.init_status_site_group()
+        tool_properties = tool_fetcher.ToolProperties(
+            tool_id='mock_tool_a', status=message.STATUS_OFFLINE)
+        self.verifyPropertiesReturnExpectedSiteIds(
+            ('abc02', 'abc03', 'xyz01'), tool_properties)
+
+    def testFetchToolsWithOnlineIpv4(self):
+        self.init_status_site_group()
+        tool_properties = tool_fetcher.ToolProperties(
+            tool_id='mock_tool_a', status=message.STATUS_ONLINE,
+            address_family=message.ADDRESS_FAMILY_IPv4)
+        self.verifyPropertiesReturnExpectedSiteIds(
+            ('abc01', 'abc02'), tool_properties)
+
+    def testFetchToolsWithOnlineIpv6(self):
+        self.init_status_site_group()
+        tool_properties = tool_fetcher.ToolProperties(
+            tool_id='mock_tool_a', status=message.STATUS_ONLINE,
+            address_family=message.ADDRESS_FAMILY_IPv6)
+        self.verifyPropertiesReturnExpectedSiteIds(
+            ('abc01', 'xyz01'), tool_properties)
+
+    #TODO(mtlynch): Test when the AF is set, but with no status, should just ignore AF
+
+    def init_country_site_group(self):
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='abc01', country='CountryA',
+            status_ipv4=message.STATUS_ONLINE,
+            status_ipv6=message.STATUS_ONLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='abc02', country='CountryA',
+            status_ipv4=message.STATUS_ONLINE,
+            status_ipv6=message.STATUS_OFFLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='def01', country='CountryA',
+            status_ipv4=message.STATUS_OFFLINE,
+            status_ipv6=message.STATUS_OFFLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='xyz01', country='CountryB',
+            status_ipv4=message.STATUS_OFFLINE,
+            status_ipv6=message.STATUS_ONLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='zzz01', country='CountryC',
+            status_ipv4=message.STATUS_OFFLINE,
+            status_ipv6=message.STATUS_ONLINE)
+
+    def testFetchToolsInCountryA(self):
+        self.init_country_site_group()
+        tool_properties = tool_fetcher.ToolProperties(
+            tool_id='mock_tool_a', country='CountryA')
+        self.verifyPropertiesReturnExpectedSiteIds(
+            ('abc01', 'abc02', 'def01'), tool_properties)
+
+    def testFetchToolsInCountryB(self):
+        self.init_country_site_group()
+        tool_properties = tool_fetcher.ToolProperties(
+            tool_id='mock_tool_a', country='CountryB')
+        self.verifyPropertiesReturnExpectedSiteIds(
+            ('xyz01',), tool_properties)
+
+    def testFetchToolsInNonExistentCountry(self):
+        self.init_country_site_group()
+        tool_properties = tool_fetcher.ToolProperties(
+            tool_id='mock_tool_a', country='non_existent_country')
+        self.verifyPropertiesReturnExpectedSiteIds([], tool_properties)
+
+    def init_metro_site_group(self):
+        self.insertSite(site_id='abc01')
+        self.insertSite(site_id='abc02')
+        self.insertSite(site_id='def01')
+        self.insertSite(site_id='def02')
+        self.insertSite(site_id='xyz01')
+
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='abc01', country='CountryA',
+            status_ipv4=message.STATUS_ONLINE,
+            status_ipv6=message.STATUS_ONLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='abc02', country='CountryA',
+            status_ipv4=message.STATUS_ONLINE,
+            status_ipv6=message.STATUS_OFFLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='def01', country='CountryA',
+            status_ipv4=message.STATUS_OFFLINE,
+            status_ipv6=message.STATUS_OFFLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='def02', country='CountryA',
+            status_ipv4=message.STATUS_OFFLINE,
+            status_ipv6=message.STATUS_ONLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='xyz01', country='CountryB',
+            status_ipv4=message.STATUS_OFFLINE,
+            status_ipv6=message.STATUS_ONLINE)
+
+    def testFetchToolsInMetroAbc(self):
+        self.init_metro_site_group()
+        tool_properties = tool_fetcher.ToolProperties(
+            tool_id='mock_tool_a', metro='abc')
+        self.verifyPropertiesReturnExpectedSiteIds(
+            ('abc01', 'abc02'), tool_properties)
+
+    def testFetchToolsInMetroXyz(self):
+        self.init_metro_site_group()
+        tool_properties = tool_fetcher.ToolProperties(
+            tool_id='mock_tool_a', metro='xyz')
+        self.verifyPropertiesReturnExpectedSiteIds(
+            ('xyz01',), tool_properties)
+
+    def testFetchToolsInNonExistentMetro(self):
+        self.init_metro_site_group()
+        tool_properties = tool_fetcher.ToolProperties(
+            tool_id='mock_tool_a', metro='qqq')
+        self.verifyPropertiesReturnExpectedSiteIds([], tool_properties)
+
+    def testFetchToolsInMetroDefWithAtLeastOneOnlineInterface(self):
+        self.init_metro_site_group()
+        tool_properties = tool_fetcher.ToolProperties(
+            tool_id='mock_tool_a', metro='def', status=message.STATUS_ONLINE)
+        self.verifyPropertiesReturnExpectedSiteIds(
+            ('def02',), tool_properties)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/server/mlabns/tests/test_tool_fetcher.py
+++ b/server/mlabns/tests/test_tool_fetcher.py
@@ -103,7 +103,7 @@ class ToolFetcherDatastoreTestCase(unittest.TestCase):
         tool_properties = tool_fetcher.ToolProperties(tool_id='no_exist_tool')
         self.verifyPropertiesReturnExpectedSiteIds([], tool_properties)
 
-    def init_status_site_group(self):
+    def initStatusSiteGroup(self):
         self.insertSliverTool(
             tool_id='mock_tool_a', site_id='abc01', country='CountryA',
             status_ipv4=message.STATUS_ONLINE,
@@ -122,21 +122,21 @@ class ToolFetcherDatastoreTestCase(unittest.TestCase):
             status_ipv6=message.STATUS_ONLINE)
 
     def testFetchToolsWithAtLeastOneOnlineInterface(self):
-        self.init_status_site_group()
+        self.initStatusSiteGroup()
         tool_properties = tool_fetcher.ToolProperties(
             tool_id='mock_tool_a', status=message.STATUS_ONLINE)
         self.verifyPropertiesReturnExpectedSiteIds(
             ('abc01', 'abc02', 'xyz01'), tool_properties)
 
     def testFetchToolsWithAtLeastOneOfflineInterface(self):
-        self.init_status_site_group()
+        self.initStatusSiteGroup()
         tool_properties = tool_fetcher.ToolProperties(
             tool_id='mock_tool_a', status=message.STATUS_OFFLINE)
         self.verifyPropertiesReturnExpectedSiteIds(
             ('abc02', 'abc03', 'xyz01'), tool_properties)
 
     def testFetchToolsWithOnlineIpv4(self):
-        self.init_status_site_group()
+        self.initStatusSiteGroup()
         tool_properties = tool_fetcher.ToolProperties(
             tool_id='mock_tool_a', status=message.STATUS_ONLINE,
             address_family=message.ADDRESS_FAMILY_IPv4)
@@ -144,16 +144,21 @@ class ToolFetcherDatastoreTestCase(unittest.TestCase):
             ('abc01', 'abc02'), tool_properties)
 
     def testFetchToolsWithOnlineIpv6(self):
-        self.init_status_site_group()
+        self.initStatusSiteGroup()
         tool_properties = tool_fetcher.ToolProperties(
             tool_id='mock_tool_a', status=message.STATUS_ONLINE,
             address_family=message.ADDRESS_FAMILY_IPv6)
         self.verifyPropertiesReturnExpectedSiteIds(
             ('abc01', 'xyz01'), tool_properties)
 
-    #TODO(mtlynch): Test when the AF is set, but with no status, should just ignore AF
+    def testFetchWhenNoAfIsSpecifiedButStatusIsOmittedIgnoreAf(self):
+        self.initStatusSiteGroup()
+        tool_properties = tool_fetcher.ToolProperties(
+            tool_id='mock_tool_a', address_family=message.ADDRESS_FAMILY_IPv6)
+        self.verifyPropertiesReturnExpectedSiteIds(
+            ('abc01', 'abc02', 'abc03', 'xyz01'), tool_properties)
 
-    def init_country_site_group(self):
+    def initCountrySiteGroup(self):
         self.insertSliverTool(
             tool_id='mock_tool_a', site_id='abc01', country='CountryA',
             status_ipv4=message.STATUS_ONLINE,
@@ -176,26 +181,26 @@ class ToolFetcherDatastoreTestCase(unittest.TestCase):
             status_ipv6=message.STATUS_ONLINE)
 
     def testFetchToolsInCountryA(self):
-        self.init_country_site_group()
+        self.initCountrySiteGroup()
         tool_properties = tool_fetcher.ToolProperties(
             tool_id='mock_tool_a', country='CountryA')
         self.verifyPropertiesReturnExpectedSiteIds(
             ('abc01', 'abc02', 'def01'), tool_properties)
 
     def testFetchToolsInCountryB(self):
-        self.init_country_site_group()
+        self.initCountrySiteGroup()
         tool_properties = tool_fetcher.ToolProperties(
             tool_id='mock_tool_a', country='CountryB')
         self.verifyPropertiesReturnExpectedSiteIds(
             ('xyz01',), tool_properties)
 
     def testFetchToolsInNonExistentCountry(self):
-        self.init_country_site_group()
+        self.initCountrySiteGroup()
         tool_properties = tool_fetcher.ToolProperties(
             tool_id='mock_tool_a', country='non_existent_country')
         self.verifyPropertiesReturnExpectedSiteIds([], tool_properties)
 
-    def init_metro_site_group(self):
+    def initMetroSiteGroup(self):
         self.insertSite(site_id='abc01')
         self.insertSite(site_id='abc02')
         self.insertSite(site_id='def01')
@@ -224,27 +229,27 @@ class ToolFetcherDatastoreTestCase(unittest.TestCase):
             status_ipv6=message.STATUS_ONLINE)
 
     def testFetchToolsInMetroAbc(self):
-        self.init_metro_site_group()
+        self.initMetroSiteGroup()
         tool_properties = tool_fetcher.ToolProperties(
             tool_id='mock_tool_a', metro='abc')
         self.verifyPropertiesReturnExpectedSiteIds(
             ('abc01', 'abc02'), tool_properties)
 
     def testFetchToolsInMetroXyz(self):
-        self.init_metro_site_group()
+        self.initMetroSiteGroup()
         tool_properties = tool_fetcher.ToolProperties(
             tool_id='mock_tool_a', metro='xyz')
         self.verifyPropertiesReturnExpectedSiteIds(
             ('xyz01',), tool_properties)
 
     def testFetchToolsInNonExistentMetro(self):
-        self.init_metro_site_group()
+        self.initMetroSiteGroup()
         tool_properties = tool_fetcher.ToolProperties(
             tool_id='mock_tool_a', metro='qqq')
         self.verifyPropertiesReturnExpectedSiteIds([], tool_properties)
 
     def testFetchToolsInMetroDefWithAtLeastOneOnlineInterface(self):
-        self.init_metro_site_group()
+        self.initMetroSiteGroup()
         tool_properties = tool_fetcher.ToolProperties(
             tool_id='mock_tool_a', metro='def', status=message.STATUS_ONLINE)
         self.verifyPropertiesReturnExpectedSiteIds(


### PR DESCRIPTION
Adds a class that retrieves SliverTool objects from the AppEngine Datastore.

This code is not yet integrated into the application, but is meant to
eventually simplify the work of the Resolver classes.