### PR TITLE
Refactors resolvers to use the ToolFetcher class

### DIFF
--- a/server/mlabns/db/model.py
+++ b/server/mlabns/db/model.py
@@ -11,6 +11,8 @@ class SliverTool(db.Model):
     site_id = db.StringProperty()
     server_id = db.StringProperty()
     server_port = db.StringProperty()
+    # TODO(mtlynch) Delete http_port. It seems to be an old, unused version of
+    # server_port.
     http_port = db.StringProperty()
     tool_extra = db.StringProperty()
 
@@ -38,6 +40,14 @@ class SliverTool(db.Model):
 
     # Date representing the last modification time of this entity.
     when = db.DateTimeProperty(auto_now=True)
+
+    def __repr__(self):
+        return (
+            '<tool_id={tool_id},site_id={site_id},slice_id={slice_id},'
+            'lat/lon=({latitude},{longitude}),geo={city},{country}>'.format(
+                tool_id=self.tool_id, site_id=self.site_id,
+                slice_id=self.slice_id, latitude=self.latitude,
+                longitude=self.longitude, city=self.city, country=self.country))
 
 class Site(db.Model):
     site_id = db.StringProperty()

--- a/server/mlabns/db/tool_fetcher.py
+++ b/server/mlabns/db/tool_fetcher.py
@@ -1,0 +1,149 @@
+import logging
+
+from google.appengine.api import memcache
+
+from mlabns.db import model
+from mlabns.util import constants
+from mlabns.util import message
+
+
+def _filter_by_status(tools, address_family, status):
+    """Filter sliver tools based on the status of their available interfaces.
+
+    Args:
+        tools: A list of sliver tools to filter by status.
+        address_family: Address family of the interface to which the status
+            parameter applies. If None, include tools that have the given
+            status on any interface.
+        status: Tool status to filter for (i.e. only return tools with this
+            status).
+
+    Returns:
+        A subset of the provided tools, filtered by status.
+    """
+    status_attrs = []
+    if address_family == message.ADDRESS_FAMILY_IPv4:
+        status_attrs.append('status_ipv4')
+    elif address_family == message.ADDRESS_FAMILY_IPv6:
+        status_attrs.append('status_ipv6')
+    else:
+        # When caller has not specified an address family, use any interface
+        status_attrs.append('status_ipv4')
+        status_attrs.append('status_ipv6')
+
+    filtered = []
+    for tool in tools:
+        for status_attr in status_attrs:
+            if getattr(tool, status_attr) == status:
+                filtered.append(tool)
+                # Exit as soon as the tool matches any set of criteria
+                break
+    return filtered
+
+
+def _find_site_ids_for_metro(metro):
+    """Determine which site IDs are present in a given metro.
+
+    Args:
+        metro: The metro for which to find site IDs.
+
+    Returns:
+        A list of site IDs for the given metro.
+    """
+    sites = model.Site.all().filter('metro =', metro).fetch(
+        constants.MAX_FETCHED_RESULTS)
+
+    if not sites:
+        logging.warning('No results found for metro %s.', metro)
+        return []
+
+    logging.info('Found %d results for metro %s.', len(sites), metro)
+    return [s.site_id for s in sites]
+
+
+class ToolProperties(object):
+    """A set of criteria to specify matching SliverTool(s)."""
+
+    def __init__(self, tool_id, status=None, address_family=None, metro=None,
+                 country=None):
+        self.tool_id = tool_id
+        self.status = status
+        self.address_family = address_family
+        self.metro = metro
+        self.country = country
+
+
+class ToolFetcher(object):
+    """Fetches SliverTools from AppEngine memcache and Datastore."""
+
+    def __init__(self):
+        self._memcache_fetcher = ToolFetcherMemcache()
+        self._datastore_fetcher = ToolFetcherDatastore()
+
+    def fetch(self, tool_properties):
+        """Fetch SliverTool objects with specified criteria.
+
+        Retrieves SliverTool objects with matching criteria. Tries to retrieve
+        from memcache first, but fails over to Datastore if memcache has no
+        matches.
+
+        Args:
+            tool_properties: A set of criteria that specifies what subset of
+                SliverTools to retrieve from the Datastore.
+
+        Returns:
+            A list of SliverTool objects that match the specified criteria.
+        """
+        results = self._memcache_fetcher.fetch(tool_properties)
+        if results:
+            return results
+
+        return self._datastore_fetcher.fetch(tool_properties)
+
+
+class ToolFetcherMemcache(object):
+
+    def fetch(self, tool_properties):
+        raise NotImplementedError()
+
+
+class ToolFetcherDatastore(object):
+    """Fetches SliverTool objects from the AppEngine Datastore."""
+
+    def fetch(self, tool_properties):
+        """Fetch SliverTool objects from the Datastore with specified criteria.
+
+        Args:
+            tool_properties: A set of criteria that specifies what subset of
+                SliverTools to retrieve from the Datastore.
+
+        Returns:
+            A list of SliverTool objects that match the specified criteria.
+        """
+        gql_clauses = ['tool_id = :tool_id']
+        if tool_properties.metro:
+            site_ids = _find_site_ids_for_metro(tool_properties.metro)
+            gql_clauses.append('site_id in :site_ids')
+        else:
+            site_ids = None
+        if tool_properties.country:
+            gql_clauses.append('country = :country')
+
+        gql = 'WHERE ' + ' AND '.join(gql_clauses)
+
+        gql_query = model.SliverTool.gql(
+            gql,
+            tool_id=tool_properties.tool_id,
+            status=tool_properties.status,
+            site_ids=site_ids,
+            country=tool_properties.country)
+        results = gql_query.fetch(constants.MAX_FETCHED_RESULTS)
+
+        # GQL doesn't have an OR operator, which makes it impossible to write
+        # GQL like (status_ipv4 = 'online' OR status_ipv6 = 'online') so we do
+        # status filtering in application code.
+        if tool_properties.status:
+            results = _filter_by_status(
+                results, tool_properties.address_family, tool_properties.status)
+
+        return results

--- a/server/mlabns/db/tool_fetcher.py
+++ b/server/mlabns/db/tool_fetcher.py
@@ -1,11 +1,11 @@
 from functools import partial
 import logging
 
-from google.appengine.api import memcache
-
 from mlabns.db import model
 from mlabns.util import constants
 from mlabns.util import message
+
+from google.appengine.api import memcache
 
 
 def _filter_by_status(tools, address_family, status):
@@ -77,6 +77,10 @@ class ToolProperties(object):
         self.address_family = address_family
         self.metro = metro
         self.country = country
+
+    def __eq__(self, other):
+        return (isinstance(other, self.__class__) and
+                self.__dict__ == other.__dict__)
 
 
 class ToolFetcher(object):

--- a/server/mlabns/tests/test_tool_fetcher.py
+++ b/server/mlabns/tests/test_tool_fetcher.py
@@ -1,0 +1,255 @@
+import unittest
+
+from mlabns.db import model
+from mlabns.db import tool_fetcher
+from mlabns.util import message
+
+from google.appengine.ext import db
+from google.appengine.ext import testbed
+
+
+class ToolFetcherDatastoreTestCase(unittest.TestCase):
+
+    def setUp(self):
+        self.testbed = testbed.Testbed()
+        self.testbed.activate()
+        self.testbed.init_datastore_v3_stub()
+        self.fetcher = tool_fetcher.ToolFetcherDatastore()
+        self.db_root = db.Model(key_name='root')
+
+    def tearDown(self):
+        self.testbed.deactivate()
+
+    def assertSiteIdsEqual(self, site_ids_expected, tools_actual):
+        site_ids_actual = [t.site_id for t in tools_actual]
+        self.assertEqual(set(site_ids_expected), set(site_ids_actual))
+
+    def verifyPropertiesReturnExpectedSiteIds(self, site_ids_expected,
+                                              tool_properties):
+        self.assertSiteIdsEqual(site_ids_expected,
+                                self.fetcher.fetch(tool_properties))
+
+    def insertSliverTool(self, tool_id, site_id=None, status_ipv4=None,
+                         status_ipv6=None, latitude=None, longitude=None,
+                         country=None):
+        tool = model.SliverTool(parent=self.db_root.key())
+        tool.tool_id = tool_id
+        tool.site_id = site_id
+        tool.status_ipv4 = status_ipv4
+        tool.status_ipv6 = status_ipv6
+        tool.latitude = latitude
+        tool.longitude = longitude
+        tool.country = country
+        tool.put()
+
+    def insertSite(self, site_id):
+        site = model.Site(parent=self.db_root.key())
+        site.site_id = site_id
+        # Metro is always a 2-tuple where the first is the metro (first three
+        # letters of the site ID) and the second is the site ID itself.
+        site.metro = [site_id[:3], site_id]
+        site.put()
+
+    def initToolIdSiteGroup(self):
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='abc01', country='CountryA',
+            status_ipv4=message.STATUS_ONLINE,
+            status_ipv6=message.STATUS_ONLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_b', site_id='abc01', country='CountryA',
+            status_ipv4=message.STATUS_ONLINE,
+            status_ipv6=message.STATUS_ONLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_c', site_id='abc01', country='CountryA',
+            status_ipv4=message.STATUS_ONLINE,
+            status_ipv6=message.STATUS_ONLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='abc02', country='CountryA',
+            status_ipv4=message.STATUS_ONLINE,
+            status_ipv6=message.STATUS_OFFLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_b', site_id='abc02', country='CountryA',
+            status_ipv4=message.STATUS_OFFLINE,
+            status_ipv6=message.STATUS_OFFLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='abc03', country='CountryA',
+            status_ipv4=message.STATUS_OFFLINE,
+            status_ipv6=message.STATUS_OFFLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_c', site_id='abc03', country='CountryA',
+            status_ipv4=message.STATUS_OFFLINE,
+            status_ipv6=message.STATUS_OFFLINE)
+
+    def testFetchToolA(self):
+        self.initToolIdSiteGroup()
+        tool_properties = tool_fetcher.ToolProperties(tool_id='mock_tool_a')
+        self.verifyPropertiesReturnExpectedSiteIds(
+            ('abc01', 'abc02', 'abc03'), tool_properties)
+
+    def testFetchToolB(self):
+        self.initToolIdSiteGroup()
+        tool_properties = tool_fetcher.ToolProperties(tool_id='mock_tool_b')
+        self.verifyPropertiesReturnExpectedSiteIds(
+            ('abc01', 'abc02'), tool_properties)
+
+    def testFetchToolC(self):
+        self.initToolIdSiteGroup()
+        tool_properties = tool_fetcher.ToolProperties(tool_id='mock_tool_c')
+        self.verifyPropertiesReturnExpectedSiteIds(
+            ('abc01', 'abc03'), tool_properties)
+
+    def testFetchNonExistentTool(self):
+        self.initToolIdSiteGroup()
+        tool_properties = tool_fetcher.ToolProperties(tool_id='no_exist_tool')
+        self.verifyPropertiesReturnExpectedSiteIds([], tool_properties)
+
+    def init_status_site_group(self):
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='abc01', country='CountryA',
+            status_ipv4=message.STATUS_ONLINE,
+            status_ipv6=message.STATUS_ONLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='abc02', country='CountryA',
+            status_ipv4=message.STATUS_ONLINE,
+            status_ipv6=message.STATUS_OFFLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='abc03', country='CountryA',
+            status_ipv4=message.STATUS_OFFLINE,
+            status_ipv6=message.STATUS_OFFLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='xyz01', country='CountryB',
+            status_ipv4=message.STATUS_OFFLINE,
+            status_ipv6=message.STATUS_ONLINE)
+
+    def testFetchToolsWithAtLeastOneOnlineInterface(self):
+        self.init_status_site_group()
+        tool_properties = tool_fetcher.ToolProperties(
+            tool_id='mock_tool_a', status=message.STATUS_ONLINE)
+        self.verifyPropertiesReturnExpectedSiteIds(
+            ('abc01', 'abc02', 'xyz01'), tool_properties)
+
+    def testFetchToolsWithAtLeastOneOfflineInterface(self):
+        self.init_status_site_group()
+        tool_properties = tool_fetcher.ToolProperties(
+            tool_id='mock_tool_a', status=message.STATUS_OFFLINE)
+        self.verifyPropertiesReturnExpectedSiteIds(
+            ('abc02', 'abc03', 'xyz01'), tool_properties)
+
+    def testFetchToolsWithOnlineIpv4(self):
+        self.init_status_site_group()
+        tool_properties = tool_fetcher.ToolProperties(
+            tool_id='mock_tool_a', status=message.STATUS_ONLINE,
+            address_family=message.ADDRESS_FAMILY_IPv4)
+        self.verifyPropertiesReturnExpectedSiteIds(
+            ('abc01', 'abc02'), tool_properties)
+
+    def testFetchToolsWithOnlineIpv6(self):
+        self.init_status_site_group()
+        tool_properties = tool_fetcher.ToolProperties(
+            tool_id='mock_tool_a', status=message.STATUS_ONLINE,
+            address_family=message.ADDRESS_FAMILY_IPv6)
+        self.verifyPropertiesReturnExpectedSiteIds(
+            ('abc01', 'xyz01'), tool_properties)
+
+    #TODO(mtlynch): Test when the AF is set, but with no status, should just ignore AF
+
+    def init_country_site_group(self):
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='abc01', country='CountryA',
+            status_ipv4=message.STATUS_ONLINE,
+            status_ipv6=message.STATUS_ONLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='abc02', country='CountryA',
+            status_ipv4=message.STATUS_ONLINE,
+            status_ipv6=message.STATUS_OFFLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='def01', country='CountryA',
+            status_ipv4=message.STATUS_OFFLINE,
+            status_ipv6=message.STATUS_OFFLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='xyz01', country='CountryB',
+            status_ipv4=message.STATUS_OFFLINE,
+            status_ipv6=message.STATUS_ONLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='zzz01', country='CountryC',
+            status_ipv4=message.STATUS_OFFLINE,
+            status_ipv6=message.STATUS_ONLINE)
+
+    def testFetchToolsInCountryA(self):
+        self.init_country_site_group()
+        tool_properties = tool_fetcher.ToolProperties(
+            tool_id='mock_tool_a', country='CountryA')
+        self.verifyPropertiesReturnExpectedSiteIds(
+            ('abc01', 'abc02', 'def01'), tool_properties)
+
+    def testFetchToolsInCountryB(self):
+        self.init_country_site_group()
+        tool_properties = tool_fetcher.ToolProperties(
+            tool_id='mock_tool_a', country='CountryB')
+        self.verifyPropertiesReturnExpectedSiteIds(
+            ('xyz01',), tool_properties)
+
+    def testFetchToolsInNonExistentCountry(self):
+        self.init_country_site_group()
+        tool_properties = tool_fetcher.ToolProperties(
+            tool_id='mock_tool_a', country='non_existent_country')
+        self.verifyPropertiesReturnExpectedSiteIds([], tool_properties)
+
+    def init_metro_site_group(self):
+        self.insertSite(site_id='abc01')
+        self.insertSite(site_id='abc02')
+        self.insertSite(site_id='def01')
+        self.insertSite(site_id='def02')
+        self.insertSite(site_id='xyz01')
+
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='abc01', country='CountryA',
+            status_ipv4=message.STATUS_ONLINE,
+            status_ipv6=message.STATUS_ONLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='abc02', country='CountryA',
+            status_ipv4=message.STATUS_ONLINE,
+            status_ipv6=message.STATUS_OFFLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='def01', country='CountryA',
+            status_ipv4=message.STATUS_OFFLINE,
+            status_ipv6=message.STATUS_OFFLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='def02', country='CountryA',
+            status_ipv4=message.STATUS_OFFLINE,
+            status_ipv6=message.STATUS_ONLINE)
+        self.insertSliverTool(
+            tool_id='mock_tool_a', site_id='xyz01', country='CountryB',
+            status_ipv4=message.STATUS_OFFLINE,
+            status_ipv6=message.STATUS_ONLINE)
+
+    def testFetchToolsInMetroAbc(self):
+        self.init_metro_site_group()
+        tool_properties = tool_fetcher.ToolProperties(
+            tool_id='mock_tool_a', metro='abc')
+        self.verifyPropertiesReturnExpectedSiteIds(
+            ('abc01', 'abc02'), tool_properties)
+
+    def testFetchToolsInMetroXyz(self):
+        self.init_metro_site_group()
+        tool_properties = tool_fetcher.ToolProperties(
+            tool_id='mock_tool_a', metro='xyz')
+        self.verifyPropertiesReturnExpectedSiteIds(
+            ('xyz01',), tool_properties)
+
+    def testFetchToolsInNonExistentMetro(self):
+        self.init_metro_site_group()
+        tool_properties = tool_fetcher.ToolProperties(
+            tool_id='mock_tool_a', metro='qqq')
+        self.verifyPropertiesReturnExpectedSiteIds([], tool_properties)
+
+    def testFetchToolsInMetroDefWithAtLeastOneOnlineInterface(self):
+        self.init_metro_site_group()
+        tool_properties = tool_fetcher.ToolProperties(
+            tool_id='mock_tool_a', metro='def', status=message.STATUS_ONLINE)
+        self.verifyPropertiesReturnExpectedSiteIds(
+            ('def02',), tool_properties)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/server/mlabns/tests/test_tool_fetcher.py
+++ b/server/mlabns/tests/test_tool_fetcher.py
@@ -103,7 +103,7 @@ class ToolFetcherDatastoreTestCase(unittest.TestCase):
         tool_properties = tool_fetcher.ToolProperties(tool_id='no_exist_tool')
         self.verifyPropertiesReturnExpectedSiteIds([], tool_properties)
 
-    def init_status_site_group(self):
+    def initStatusSiteGroup(self):
         self.insertSliverTool(
             tool_id='mock_tool_a', site_id='abc01', country='CountryA',
             status_ipv4=message.STATUS_ONLINE,
@@ -122,21 +122,21 @@ class ToolFetcherDatastoreTestCase(unittest.TestCase):
             status_ipv6=message.STATUS_ONLINE)
 
     def testFetchToolsWithAtLeastOneOnlineInterface(self):
-        self.init_status_site_group()
+        self.initStatusSiteGroup()
         tool_properties = tool_fetcher.ToolProperties(
             tool_id='mock_tool_a', status=message.STATUS_ONLINE)
         self.verifyPropertiesReturnExpectedSiteIds(
             ('abc01', 'abc02', 'xyz01'), tool_properties)
 
     def testFetchToolsWithAtLeastOneOfflineInterface(self):
-        self.init_status_site_group()
+        self.initStatusSiteGroup()
         tool_properties = tool_fetcher.ToolProperties(
             tool_id='mock_tool_a', status=message.STATUS_OFFLINE)
         self.verifyPropertiesReturnExpectedSiteIds(
             ('abc02', 'abc03', 'xyz01'), tool_properties)
 
     def testFetchToolsWithOnlineIpv4(self):
-        self.init_status_site_group()
+        self.initStatusSiteGroup()
         tool_properties = tool_fetcher.ToolProperties(
             tool_id='mock_tool_a', status=message.STATUS_ONLINE,
             address_family=message.ADDRESS_FAMILY_IPv4)
@@ -144,16 +144,21 @@ class ToolFetcherDatastoreTestCase(unittest.TestCase):
             ('abc01', 'abc02'), tool_properties)
 
     def testFetchToolsWithOnlineIpv6(self):
-        self.init_status_site_group()
+        self.initStatusSiteGroup()
         tool_properties = tool_fetcher.ToolProperties(
             tool_id='mock_tool_a', status=message.STATUS_ONLINE,
             address_family=message.ADDRESS_FAMILY_IPv6)
         self.verifyPropertiesReturnExpectedSiteIds(
             ('abc01', 'xyz01'), tool_properties)
 
-    #TODO(mtlynch): Test when the AF is set, but with no status, should just ignore AF
+    def testFetchWhenNoAfIsSpecifiedButStatusIsOmittedIgnoreAf(self):
+        self.initStatusSiteGroup()
+        tool_properties = tool_fetcher.ToolProperties(
+            tool_id='mock_tool_a', address_family=message.ADDRESS_FAMILY_IPv6)
+        self.verifyPropertiesReturnExpectedSiteIds(
+            ('abc01', 'abc02', 'abc03', 'xyz01'), tool_properties)
 
-    def init_country_site_group(self):
+    def initCountrySiteGroup(self):
         self.insertSliverTool(
             tool_id='mock_tool_a', site_id='abc01', country='CountryA',
             status_ipv4=message.STATUS_ONLINE,
@@ -176,26 +181,26 @@ class ToolFetcherDatastoreTestCase(unittest.TestCase):
             status_ipv6=message.STATUS_ONLINE)
 
     def testFetchToolsInCountryA(self):
-        self.init_country_site_group()
+        self.initCountrySiteGroup()
         tool_properties = tool_fetcher.ToolProperties(
             tool_id='mock_tool_a', country='CountryA')
         self.verifyPropertiesReturnExpectedSiteIds(
             ('abc01', 'abc02', 'def01'), tool_properties)
 
     def testFetchToolsInCountryB(self):
-        self.init_country_site_group()
+        self.initCountrySiteGroup()
         tool_properties = tool_fetcher.ToolProperties(
             tool_id='mock_tool_a', country='CountryB')
         self.verifyPropertiesReturnExpectedSiteIds(
             ('xyz01',), tool_properties)
 
     def testFetchToolsInNonExistentCountry(self):
-        self.init_country_site_group()
+        self.initCountrySiteGroup()
         tool_properties = tool_fetcher.ToolProperties(
             tool_id='mock_tool_a', country='non_existent_country')
         self.verifyPropertiesReturnExpectedSiteIds([], tool_properties)
 
-    def init_metro_site_group(self):
+    def initMetroSiteGroup(self):
         self.insertSite(site_id='abc01')
         self.insertSite(site_id='abc02')
         self.insertSite(site_id='def01')
@@ -224,27 +229,27 @@ class ToolFetcherDatastoreTestCase(unittest.TestCase):
             status_ipv6=message.STATUS_ONLINE)
 
     def testFetchToolsInMetroAbc(self):
-        self.init_metro_site_group()
+        self.initMetroSiteGroup()
         tool_properties = tool_fetcher.ToolProperties(
             tool_id='mock_tool_a', metro='abc')
         self.verifyPropertiesReturnExpectedSiteIds(
             ('abc01', 'abc02'), tool_properties)
 
     def testFetchToolsInMetroXyz(self):
-        self.init_metro_site_group()
+        self.initMetroSiteGroup()
         tool_properties = tool_fetcher.ToolProperties(
             tool_id='mock_tool_a', metro='xyz')
         self.verifyPropertiesReturnExpectedSiteIds(
             ('xyz01',), tool_properties)
 
     def testFetchToolsInNonExistentMetro(self):
-        self.init_metro_site_group()
+        self.initMetroSiteGroup()
         tool_properties = tool_fetcher.ToolProperties(
             tool_id='mock_tool_a', metro='qqq')
         self.verifyPropertiesReturnExpectedSiteIds([], tool_properties)
 
     def testFetchToolsInMetroDefWithAtLeastOneOnlineInterface(self):
-        self.init_metro_site_group()
+        self.initMetroSiteGroup()
         tool_properties = tool_fetcher.ToolProperties(
             tool_id='mock_tool_a', metro='def', status=message.STATUS_ONLINE)
         self.verifyPropertiesReturnExpectedSiteIds(

--- a/server/mlabns/tests/test_tool_fetcher.py
+++ b/server/mlabns/tests/test_tool_fetcher.py
@@ -1,24 +1,78 @@
+import collections
 import unittest
+
+import mock
 
 from mlabns.db import model
 from mlabns.db import tool_fetcher
+from mlabns.util import constants
 from mlabns.util import message
 
+from google.appengine.api import memcache
 from google.appengine.ext import db
 from google.appengine.ext import testbed
 
 
-class ToolFetcherDatastoreTestCase(unittest.TestCase):
+class ToolFetcherTestCase(unittest.TestCase):
 
     def setUp(self):
-        self.testbed = testbed.Testbed()
-        self.testbed.activate()
-        self.testbed.init_datastore_v3_stub()
-        self.fetcher = tool_fetcher.ToolFetcherDatastore()
-        self.db_root = db.Model(key_name='root')
+        tool_fetcher_datastore_patch = mock.patch.object(
+                tool_fetcher, 'ToolFetcherDatastore', autospec=True)
+        self.addCleanup(tool_fetcher_datastore_patch.stop)
+        tool_fetcher_datastore_patch.start()
 
-    def tearDown(self):
-        self.testbed.deactivate()
+        tool_fetcher_memcache_patch = mock.patch.object(
+                tool_fetcher, 'ToolFetcherMemcache', autospec=True)
+        self.addCleanup(tool_fetcher_memcache_patch.stop)
+        tool_fetcher_memcache_patch.start()
+
+        self.fetcher = tool_fetcher.ToolFetcher()
+
+    def testFetchDoesNotHitDatastoreIfMemcacheHasRequiredData(self):
+        # The mock response is just ints here for simplicity, though the real
+        # function returns
+        mock_memcache_response = [1, 2, 3]
+        tool_fetcher.ToolFetcherMemcache().fetch.return_value = (
+                mock_memcache_response)
+        tool_properties = tool_fetcher.ToolProperties(tool_id='mock_tool_a')
+        fetcher_results_actual = self.fetcher.fetch(tool_properties)
+        self.assertSequenceEqual(mock_memcache_response, fetcher_results_actual)
+
+        # Verify that we did not attempt to read from the Datastore
+        self.assertFalse(tool_fetcher.ToolFetcherDatastore().fetch.called)
+
+    def testFetchFailsOverToDatastoreWhenDataIsNotInMemcache(self):
+        tool_fetcher.ToolFetcherMemcache().fetch.return_value = []
+        # The mock response is just ints here for simplicity, though the real
+        # function returns SliverTool objects.
+        mock_datastore_response = [4, 5, 6]
+        tool_fetcher.ToolFetcherDatastore().fetch.return_value = (
+                mock_datastore_response)
+        tool_properties = tool_fetcher.ToolProperties(tool_id='mock_tool_a')
+        fetcher_results_actual = self.fetcher.fetch(tool_properties)
+        self.assertSequenceEqual(mock_datastore_response,
+                                 fetcher_results_actual)
+
+
+class ToolFetcherCommonTests(object):
+    """Common tests that apply to both the Datastore and Memcache fetchers."""
+
+    def createSliverTool(self, tool_id, site_id=None, status_ipv4=None,
+                         status_ipv6=None, latitude=None, longitude=None,
+                         country=None):
+        tool = model.SliverTool()
+        tool.tool_id = tool_id
+        tool.site_id = site_id
+        tool.status_ipv4 = status_ipv4
+        tool.status_ipv6 = status_ipv6
+        tool.latitude = latitude
+        tool.longitude = longitude
+        tool.country = country
+        self.created_tools.append(tool)
+
+    def insertCreatedTools(self):
+        """Subclasses must implement this function."""
+        pass
 
     def assertSiteIdsEqual(self, site_ids_expected, tools_actual):
         site_ids_actual = [t.site_id for t in tools_actual]
@@ -29,56 +83,36 @@ class ToolFetcherDatastoreTestCase(unittest.TestCase):
         self.assertSiteIdsEqual(site_ids_expected,
                                 self.fetcher.fetch(tool_properties))
 
-    def insertSliverTool(self, tool_id, site_id=None, status_ipv4=None,
-                         status_ipv6=None, latitude=None, longitude=None,
-                         country=None):
-        tool = model.SliverTool(parent=self.db_root.key())
-        tool.tool_id = tool_id
-        tool.site_id = site_id
-        tool.status_ipv4 = status_ipv4
-        tool.status_ipv6 = status_ipv6
-        tool.latitude = latitude
-        tool.longitude = longitude
-        tool.country = country
-        tool.put()
-
-    def insertSite(self, site_id):
-        site = model.Site(parent=self.db_root.key())
-        site.site_id = site_id
-        # Metro is always a 2-tuple where the first is the metro (first three
-        # letters of the site ID) and the second is the site ID itself.
-        site.metro = [site_id[:3], site_id]
-        site.put()
-
     def initToolIdSiteGroup(self):
-        self.insertSliverTool(
+        self.createSliverTool(
             tool_id='mock_tool_a', site_id='abc01', country='CountryA',
             status_ipv4=message.STATUS_ONLINE,
             status_ipv6=message.STATUS_ONLINE)
-        self.insertSliverTool(
+        self.createSliverTool(
             tool_id='mock_tool_b', site_id='abc01', country='CountryA',
             status_ipv4=message.STATUS_ONLINE,
             status_ipv6=message.STATUS_ONLINE)
-        self.insertSliverTool(
+        self.createSliverTool(
             tool_id='mock_tool_c', site_id='abc01', country='CountryA',
             status_ipv4=message.STATUS_ONLINE,
             status_ipv6=message.STATUS_ONLINE)
-        self.insertSliverTool(
+        self.createSliverTool(
             tool_id='mock_tool_a', site_id='abc02', country='CountryA',
             status_ipv4=message.STATUS_ONLINE,
             status_ipv6=message.STATUS_OFFLINE)
-        self.insertSliverTool(
+        self.createSliverTool(
             tool_id='mock_tool_b', site_id='abc02', country='CountryA',
             status_ipv4=message.STATUS_OFFLINE,
             status_ipv6=message.STATUS_OFFLINE)
-        self.insertSliverTool(
+        self.createSliverTool(
             tool_id='mock_tool_a', site_id='abc03', country='CountryA',
             status_ipv4=message.STATUS_OFFLINE,
             status_ipv6=message.STATUS_OFFLINE)
-        self.insertSliverTool(
+        self.createSliverTool(
             tool_id='mock_tool_c', site_id='abc03', country='CountryA',
             status_ipv4=message.STATUS_OFFLINE,
             status_ipv6=message.STATUS_OFFLINE)
+        self.insertCreatedTools()
 
     def testFetchToolA(self):
         self.initToolIdSiteGroup()
@@ -104,22 +138,23 @@ class ToolFetcherDatastoreTestCase(unittest.TestCase):
         self.verifyPropertiesReturnExpectedSiteIds([], tool_properties)
 
     def initStatusSiteGroup(self):
-        self.insertSliverTool(
+        self.createSliverTool(
             tool_id='mock_tool_a', site_id='abc01', country='CountryA',
             status_ipv4=message.STATUS_ONLINE,
             status_ipv6=message.STATUS_ONLINE)
-        self.insertSliverTool(
+        self.createSliverTool(
             tool_id='mock_tool_a', site_id='abc02', country='CountryA',
             status_ipv4=message.STATUS_ONLINE,
             status_ipv6=message.STATUS_OFFLINE)
-        self.insertSliverTool(
+        self.createSliverTool(
             tool_id='mock_tool_a', site_id='abc03', country='CountryA',
             status_ipv4=message.STATUS_OFFLINE,
             status_ipv6=message.STATUS_OFFLINE)
-        self.insertSliverTool(
+        self.createSliverTool(
             tool_id='mock_tool_a', site_id='xyz01', country='CountryB',
             status_ipv4=message.STATUS_OFFLINE,
             status_ipv6=message.STATUS_ONLINE)
+        self.insertCreatedTools()
 
     def testFetchToolsWithAtLeastOneOnlineInterface(self):
         self.initStatusSiteGroup()
@@ -159,26 +194,27 @@ class ToolFetcherDatastoreTestCase(unittest.TestCase):
             ('abc01', 'abc02', 'abc03', 'xyz01'), tool_properties)
 
     def initCountrySiteGroup(self):
-        self.insertSliverTool(
+        self.createSliverTool(
             tool_id='mock_tool_a', site_id='abc01', country='CountryA',
             status_ipv4=message.STATUS_ONLINE,
             status_ipv6=message.STATUS_ONLINE)
-        self.insertSliverTool(
+        self.createSliverTool(
             tool_id='mock_tool_a', site_id='abc02', country='CountryA',
             status_ipv4=message.STATUS_ONLINE,
             status_ipv6=message.STATUS_OFFLINE)
-        self.insertSliverTool(
+        self.createSliverTool(
             tool_id='mock_tool_a', site_id='def01', country='CountryA',
             status_ipv4=message.STATUS_OFFLINE,
             status_ipv6=message.STATUS_OFFLINE)
-        self.insertSliverTool(
+        self.createSliverTool(
             tool_id='mock_tool_a', site_id='xyz01', country='CountryB',
             status_ipv4=message.STATUS_OFFLINE,
             status_ipv6=message.STATUS_ONLINE)
-        self.insertSliverTool(
+        self.createSliverTool(
             tool_id='mock_tool_a', site_id='zzz01', country='CountryC',
             status_ipv4=message.STATUS_OFFLINE,
             status_ipv6=message.STATUS_ONLINE)
+        self.insertCreatedTools()
 
     def testFetchToolsInCountryA(self):
         self.initCountrySiteGroup()
@@ -200,6 +236,64 @@ class ToolFetcherDatastoreTestCase(unittest.TestCase):
             tool_id='mock_tool_a', country='non_existent_country')
         self.verifyPropertiesReturnExpectedSiteIds([], tool_properties)
 
+
+class ToolFetcherMemcacheTestCase(unittest.TestCase, ToolFetcherCommonTests):
+
+    def setUp(self):
+        self.testbed = testbed.Testbed()
+        self.testbed.activate()
+        self.testbed.init_memcache_stub()
+        self.fetcher = tool_fetcher.ToolFetcherMemcache()
+        self.created_tools = []
+
+    def tearDown(self):
+        self.testbed.deactivate()
+
+    def insertCreatedTools(self):
+        tools_by_id = collections.defaultdict(lambda: [])
+        for tool in self.created_tools:
+            tools_by_id[tool.tool_id].append(tool)
+        for tool_id, tool_list in tools_by_id.iteritems():
+            memcache.set(tool_id, tool_list,
+                         namespace=constants.MEMCACHE_NAMESPACE_TOOLS)
+
+    def testFetchAlwaysReturnsNoResultsWhenMetroIsSet(self):
+        """Memcache fetcher has no knowledge of metros, so returns nothing."""
+        self.createSliverTool(
+            tool_id='mock_tool_a', site_id='abc01', country='CountryA',
+            status_ipv4=message.STATUS_ONLINE,
+            status_ipv6=message.STATUS_ONLINE)
+        tool_properties = tool_fetcher.ToolProperties(
+            tool_id='mock_tool_a', metro='abc')
+        self.verifyPropertiesReturnExpectedSiteIds([], tool_properties)
+
+
+class ToolFetcherDatastoreTestCase(unittest.TestCase, ToolFetcherCommonTests):
+
+    def setUp(self):
+        self.testbed = testbed.Testbed()
+        self.testbed.activate()
+        self.testbed.init_datastore_v3_stub()
+        self.fetcher = tool_fetcher.ToolFetcherDatastore()
+        self.db_root = db.Model(key_name='root')
+        self.created_tools = []
+
+    def tearDown(self):
+        self.testbed.deactivate()
+
+    def insertCreatedTools(self):
+        for tool in self.created_tools:
+            tool.parent = parent=self.db_root.key()
+            tool.put()
+
+    def insertSite(self, site_id):
+        site = model.Site(parent=self.db_root.key())
+        site.site_id = site_id
+        # Metro is always a 2-tuple where the first is the metro (first three
+        # letters of the site ID) and the second is the site ID itself.
+        site.metro = [site_id[:3], site_id]
+        site.put()
+
     def initMetroSiteGroup(self):
         self.insertSite(site_id='abc01')
         self.insertSite(site_id='abc02')
@@ -207,26 +301,27 @@ class ToolFetcherDatastoreTestCase(unittest.TestCase):
         self.insertSite(site_id='def02')
         self.insertSite(site_id='xyz01')
 
-        self.insertSliverTool(
+        self.createSliverTool(
             tool_id='mock_tool_a', site_id='abc01', country='CountryA',
             status_ipv4=message.STATUS_ONLINE,
             status_ipv6=message.STATUS_ONLINE)
-        self.insertSliverTool(
+        self.createSliverTool(
             tool_id='mock_tool_a', site_id='abc02', country='CountryA',
             status_ipv4=message.STATUS_ONLINE,
             status_ipv6=message.STATUS_OFFLINE)
-        self.insertSliverTool(
+        self.createSliverTool(
             tool_id='mock_tool_a', site_id='def01', country='CountryA',
             status_ipv4=message.STATUS_OFFLINE,
             status_ipv6=message.STATUS_OFFLINE)
-        self.insertSliverTool(
+        self.createSliverTool(
             tool_id='mock_tool_a', site_id='def02', country='CountryA',
             status_ipv4=message.STATUS_OFFLINE,
             status_ipv6=message.STATUS_ONLINE)
-        self.insertSliverTool(
+        self.createSliverTool(
             tool_id='mock_tool_a', site_id='xyz01', country='CountryB',
             status_ipv4=message.STATUS_OFFLINE,
             status_ipv6=message.STATUS_ONLINE)
+        self.insertCreatedTools()
 
     def testFetchToolsInMetroAbc(self):
         self.initMetroSiteGroup()

--- a/server/mlabns/util/resolver.py
+++ b/server/mlabns/util/resolver.py
@@ -1,138 +1,103 @@
-from google.appengine.api import memcache
+import logging
+import random
 
-from mlabns.db import model
-from mlabns.util import constants
+from mlabns.db import tool_fetcher
 from mlabns.util import distance
 from mlabns.util import message
-from mlabns.util import sliver_tool_distance
-
-import logging
-import math
-import random
-from operator import attrgetter
 
 
-class ResolverBase:
+def _tool_properties_from_query(query):
+    """Create ToolProperties from a LookupQuery.
+
+    Creates a ToolProperties object for use with a resolver, based on a
+    LookupQuery. Note that it only initializes common properties shared
+    by all resolvers (e.g. status, tool_id) whereas resolver-specific properties
+    (e.g. country, metro) are not initialized here.
+
+    Args:
+        query: LookupQuery from which to create ToolProperties
+
+    Returns:
+        A ToolProperties object initialized from the query provided.
+    """
+    tool_properties = tool_fetcher.ToolProperties(
+        tool_id=query.tool_id, status=message.STATUS_ONLINE)
+    if query.address_family:
+        tool_properties.address_family = query.address_family
+    return tool_properties
+
+
+class ResolverBase(object):
     """Resolver base class."""
 
-    def get_candidates(self, query):
-        """Find candidates for server selection.
+    def __init__(self):
+        self.tool_fetcher = tool_fetcher.ToolFetcher()
 
-        Args:
-            query: A LookupQuery instance.
+    def _get_matching_candidates(self, query):
+        tool_properties = _tool_properties_from_query(query)
+        return self._fetch_tools_with_properties(tool_properties)
 
-        Returns:
-            A list of SliverTool entities that match the requirements
-            specified in the 'query'.
-        """
-        candidates = []
-        if query.address_family is not None:
-            candidates = self._get_candidates(query, query.address_family)
-        # If no candidates with this address family and if this address family
-        # was not user-defined, try the other address family.
-        if len(candidates) == 0 and \
-            query.address_family != query.user_defined_af:
-            if query.address_family == message.ADDRESS_FAMILY_IPv4:
-                candidates = self._get_candidates(query,
-                                                  message.ADDRESS_FAMILY_IPv6)
-            elif query.address_family == message.ADDRESS_FAMILY_IPv6:
-                candidates = self._get_candidates(query,
-                                                  message.ADDRESS_FAMILY_IPv4)
+    def _fetch_tools_with_properties(self, tool_properties):
+        candidates = self.tool_fetcher.fetch(tool_properties)
+        if not candidates:
+            logging.error('No results found for %s.', tool_properties.tool_id)
+            return None
         return candidates
 
-    def _get_candidates(self, query, address_family):
-        """Returns a (possibly empty) list of available candidates."""
-        logging.info('Looking for %s in memcache.', query.tool_id)
-        # First try to get the sliver tools from the memcache.
-        sliver_tools = memcache.get(
-            query.tool_id, namespace=constants.MEMCACHE_NAMESPACE_TOOLS)
-        if sliver_tools is not None:
-            logging.info('Sliver tools found in memcache (%s results).',
-                         len(sliver_tools))
-            candidates = []
-            for sliver_tool in sliver_tools:
-                if (address_family == message.ADDRESS_FAMILY_IPv4 and
-                    sliver_tool.status_ipv4 == message.STATUS_ONLINE) or \
-                    (address_family == message.ADDRESS_FAMILY_IPv6 and
-                    sliver_tool.status_ipv6 == message.STATUS_ONLINE):
-                    candidates.append(sliver_tool)
-            logging.info('After filtering, %d candidates match criteria.',
-                         len(candidates))
-            return candidates
-        logging.info(
-            'Sliver tools not found in memcache, falling back to data store.')
-
-        # Get the sliver tools from datastore.
-        status_field = 'status_' + address_family
-        candidates = model.SliverTool.gql(
-            'WHERE tool_id = :tool_id '
-            'AND ' + status_field + ' = :status',
-            tool_id=query.tool_id,
-            status=message.STATUS_ONLINE)
-        logging.info('Found %s candidates in data store', candidates.count())
-        return candidates.fetch(constants.MAX_FETCHED_RESULTS)
-
-    def _get_candidates_from_sites(self, query, address_family, site_id_list):
-        """Returns a (possibly empty) list of available candidates."""
-        logging.info('Looking for %s in memcache', query.tool_id)
-        # First try to get the sliver tools from the cache.
-        sliver_tools = memcache.get(
-            query.tool_id, namespace=constants.MEMCACHE_NAMESPACE_TOOLS)
-        if sliver_tools is not None:
-            logging.info('Sliver tools found in memcache (%s results).',
-                         len(sliver_tools))
-            candidates = []
-            for sliver_tool in sliver_tools:
-                if sliver_tool.site_id in site_id_list and \
-                    ((address_family == message.ADDRESS_FAMILY_IPv4 and
-                    sliver_tool.status_ipv4 == message.STATUS_ONLINE) or
-                    (address_family == message.ADDRESS_FAMILY_IPv6 and
-                    sliver_tool.status_ipv6 == message.STATUS_ONLINE)):
-                    candidates.append(sliver_tool)
-            logging.info('After filtering, %d candidates match criteria.',
-                         len(candidates))
-            return candidates
-        logging.info(
-            'Sliver tools not found in memcache, falling back to data store.')
-
-        # Get the sliver tools from datastore.
-        status_field = 'status_' + address_family
-        candidates = model.SliverTool.gql(
-            'WHERE tool_id = :tool_id '
-            'AND ' + status_field + ' = :status '
-            'AND site_id in :site_id_list',
-            tool_id=query.tool_id,
-            status=message.STATUS_ONLINE,
-            site_id_list=site_id_list)
-        logging.info('Found %s candidates in data store', candidates.count())
-        return candidates.fetch(constants.MAX_FETCHED_RESULTS)
-
-    def answer_query(self, query):
-        """Selects a random sliver tool among the available candidates.
-
-        Args:
-            query: A LookupQuery instance.
-
-        Returns:
-            A SliverTool entity if any available, None otherwise.
-        """
-        candidates = self.get_candidates(query)
-        if len(candidates) == 0:
-            logging.error('No results found for %s.', query.tool_id)
-            return None
-
-        return [random.choice(candidates)]
 
 class AllResolver(ResolverBase):
+
     def answer_query(self, query):
-        candidates = self.get_candidates(query)
-        if len(candidates) == 0:
-            logging.error('No results found for %s.', query.tool_id)
-            return None
-        return candidates
+        return self._get_matching_candidates(query)
+
 
 class GeoResolver(ResolverBase):
     """Chooses the server geographically closest to the client."""
+
+    def _get_closest_n_candidates(self, query, max_results):
+        """Selects the top N geographically closest SliverTools to the client.
+
+        Finds the top N closest SliverTools to the client and returns them.
+        Note that N is currently hardcoded to 4.
+
+        Args:
+            query: A LookupQuery instance.
+            max_results: The maximum number of candidates to return.
+
+        Returns:
+            A list of SliverTool entities on success, or None if there is no
+            SliverTool available that matches the query.
+        """
+        candidates = self._get_matching_candidates(query)
+        if not candidates:
+            return None
+
+        if (query.latitude is None) or (query.longitude is None):
+            logging.warning(
+                'No latitude/longitude, return a random sliver tool.')
+            return [random.choice(candidates)]
+
+        # Pre-shuffle the candidates to randomize the order of equidistant
+        # results.
+        random.shuffle(candidates)
+
+        site_distances = {}
+        tool_distances = []
+        for candidate in candidates:
+            if candidate.site_id not in site_distances:
+                site_distances[candidate.site_id] = distance.distance(
+                    query.latitude, query.longitude, candidate.latitude,
+                    candidate.longitude)
+            tool_distances.append(
+                {'distance': site_distances[candidate.site_id],
+                 'tool': candidate})
+
+        # Sort the tools by distance
+        tool_distances.sort(key=lambda t: t['distance'])
+
+        # Create a new list of just the sorted SliverTool objects.
+        sorted_tools = [t['tool'] for t in tool_distances]
+        return sorted_tools[:max_results]
 
     def answer_query(self, query):
         """Selects the geographically closest SliverTool.
@@ -141,54 +106,13 @@ class GeoResolver(ResolverBase):
             query: A LookupQuery instance.
 
         Returns:
-            A SliverTool entity in case of success, or None if there is no
-            SliverTool available that matches the query.
+            A single-element list of SliverTools in case of success, or None if
+            there is no SliverTool available that matches the query.
         """
-        candidates = self.get_candidates(query)
-        if len(candidates) == 0:
-            logging.error('No results found for %s.', query.tool_id)
-            return None
-
-        if (query.latitude is None) or (query.longitude is None):
-            logging.warning('No latide/longitude, return a random sliver tool.')
-            return [random.choice(candidates)]
-
-        min_distance = float('+inf')
-        closest_sliver_tools = []
-        distances = {}
-
-        # Compute for each SliverTool the distance and add keep in the
-        # 'closest_sliver_tools' list only the SliverTools whose distance is
-        # less or equal than the current minimum.
-        for sliver_tool in candidates:
-            # Check if we already computed the distance of this site.
-            if distances.has_key(sliver_tool.site_id):
-                current_distance = distances[sliver_tool.site_id]
-            else:
-                current_distance = distance.distance(
-                    query.latitude,
-                    query.longitude,
-                    sliver_tool.latitude,
-                    sliver_tool.longitude)
-
-                distances[sliver_tool.site_id] = current_distance
-
-            # Update the min distance and add the SliverTool to the list.
-            if current_distance < min_distance:
-                min_distance = current_distance
-                closest_sliver_tools = [sliver_tool]
-            elif current_distance == min_distance:
-                closest_sliver_tools.append(sliver_tool)
-
-        # Add the min_distance to the query so it can be logged later. Round to
-        # the next highest kilometre radius to remove precision.
-        query.distance = math.ceil(min_distance)
-
-        # Choose randomly among candidates with the same, minimum distance.
-        return [random.choice(closest_sliver_tools)]
+        return self._get_closest_n_candidates(query, 1)
 
 
-class GeoResolverWithOptions(ResolverBase):
+class GeoResolverWithOptions(GeoResolver):
     """Chooses the N geographically closest servers to the client."""
 
     def answer_query(self, query):
@@ -201,86 +125,71 @@ class GeoResolverWithOptions(ResolverBase):
             query: A LookupQuery instance.
 
         Returns:
-            A list of SliverTool entities on success, or None if there is no
-            SliverTool available that matches the query.
+            A list of SliverTools on success, or None if there is no SliverTool
+            available that matches the query.
         """
-        # Return no more than MAX_RESULTS SliverTools in the result.
-        MAX_RESULTS = 4
-        candidates = self.get_candidates(query)
-        if len(candidates) == 0:
-            logging.error('No results found for %s.', query.tool_id)
-            return None
-
-        if (query.latitude is None) or (query.longitude is None):
-            logging.warning('No latide/longitude, return a random sliver tool.')
-            return [random.choice(candidates)]
-
-        min_distance = float('+inf')
-        sliver_tool_bins = {}
-        sliver_tools = []
-        distances = {}
-
-        # Combine the candidates into bins by site.
-        for sliver_tool in candidates:
-            if not sliver_tool_bins.has_key(sliver_tool.site_id):
-                sliver_tool_bins[sliver_tool.site_id] = [sliver_tool]
-            else:
-                sliver_tool_bins[sliver_tool.site_id].append(sliver_tool)
-
-        for site_id in sliver_tool_bins:
-            # Take a random sliver from the list.
-            sliver_tool = random.choice(sliver_tool_bins[site_id])
-            # Check if we already computed the distance of this site.
-            if distances.has_key(sliver_tool.site_id):
-                current_distance = distances[sliver_tool.site_id]
-            else:
-                current_distance = distance.distance(
-                    query.latitude,
-                    query.longitude,
-                    sliver_tool.latitude,
-                    sliver_tool.longitude)
-                distances[sliver_tool.site_id] = current_distance
-
-            sliver_tools.append(\
-                sliver_tool_distance.SliverToolDistance(sliver_tool, \
-                                                        current_distance))
-
-        sliver_tools_sorted = sorted(sliver_tools, key=attrgetter('distance'))
-        final_results = []
-        for std in sliver_tools_sorted:
-            final_results.append(std.sliver_tool)
-        return final_results[:MAX_RESULTS]
+        # TODO(mtlynch): N is currently hardcoded to 4 here due to concern that
+        # changing the value would break compatibility with uTorrent clients. If
+        # uTorrent clients can gracefully handle responses where n=1, we should
+        # get rid of GeoResolverWithOptions and just use GeoResolver.
+        return self._get_closest_n_candidates(query, 4)
 
 
 class MetroResolver(ResolverBase):
     """Implements the metro policy."""
 
-    def _get_candidates(self, query, address_family):
-        # TODO(claudiu) Test whether the following query is better.
-        # sites = model.Site.gql("WHERE metro = :metro", metro=query.metro)
-        sites = model.Site.all().filter("metro =", query.metro).fetch(
-            constants.MAX_FETCHED_RESULTS)
-        logging.info(
-            'Found %s results for metro %s.', len(sites), query.metro)
-        if len(sites) == 0:
-            logging.info('No results found for metro %s.', query.metro)
-            return []
+    def _get_matching_candidates(self, query):
+        tool_properties = _tool_properties_from_query(query)
+        tool_properties.metro = query.metro
+        return self._fetch_tools_with_properties(tool_properties)
 
-        site_id_list = []
-        for site in sites:
-            site_id_list.append(site.site_id)
+    def answer_query(self, query):
+        """Returns a SliverTool in a specified metro.
 
-        return self._get_candidates_from_sites(
-            query, address_family, site_id_list)
+        Args:
+            query: A LookupQuery instance.
+
+        Returns:
+            A single-element list of SliverTools if a valid match exists, None
+            otherwise.
+        """
+        if not query.metro:
+            return None
+
+        candidates = self._get_matching_candidates(query)
+        if not candidates:
+            return None
+
+        return [random.choice(candidates)]
 
 
 class RandomResolver(ResolverBase):
     """Returns a server chosen randomly."""
-    pass
+
+    def answer_query(self, query):
+        """Selects a random sliver tool among the available candidates.
+
+        Args:
+            query: A LookupQuery instance.
+
+        Returns:
+            A single-element list of SliverTools if a valid match exists, None
+            otherwise.
+        """
+        candidates = self._get_matching_candidates(query)
+        if not candidates:
+            return None
+
+        return [random.choice(candidates)]
 
 
 class CountryResolver(ResolverBase):
     """Returns a server in a specified country."""
+
+    def _get_matching_candidates(self, query):
+        tool_properties = _tool_properties_from_query(query)
+        tool_properties.country = query.country
+        return self._fetch_tools_with_properties(tool_properties)
 
     def answer_query(self, query):
         """Returns a SliverTool in a specified country.
@@ -289,24 +198,17 @@ class CountryResolver(ResolverBase):
             query: A LookupQuery instance.
 
         Returns:
-            A SliverTool entity if available, None otherwise.
+            A single-element list of SliverTools if a valid match exists, None
+            otherwise.
         """
-        if query.user_defined_country is None:
+        if not query.country:
             return None
 
-        candidates = self.get_candidates(query)
-        if len(candidates) == 0:
-            logging.error('No results found for %s.', query.tool_id)
+        candidates = self._get_matching_candidates(query)
+        if not candidates:
             return None
 
-        country_candidates = []
-        for candidate in candidates:
-            if candidate.country == query.user_defined_country:
-                country_candidates.append(candidate)
-
-        if len(country_candidates) == 0:
-            return None
-        return [random.choice(country_candidates)]
+        return [random.choice(candidates)]
 
 
 def new_resolver(policy):

--- a/server/mlabns/util/sliver_tool_distance.py
+++ b/server/mlabns/util/sliver_tool_distance.py
@@ -1,4 +1,0 @@
-class SliverToolDistance:
-    def __init__(self, sliver_tool, distance):
-        self.distance = distance
-        self.sliver_tool = sliver_tool


### PR DESCRIPTION
This simplifies the implementation of the Resolver* classes by moving
the details of memcache/datastore into the ToolFetcher class. This also
includes a mostly complete rewrite of the unit tests for the Resolver
classes, as the previous implementation was very flaky and did not
effectively test the public APIs of the resolver classes.