### PR TITLE
Fix map status

### DIFF
--- a/server/mlabns/templates/map_view.html
+++ b/server/mlabns/templates/map_view.html
@@ -33,6 +33,10 @@
       var offlineMarkersArray = [];
       var errorMarkersArray = [];
 
+      function isProductionServer(serverName) {
+        return /^mlab[0-3]$/.test(serverName);
+      }
+
       function initialize() {
         var mapOptions = {
           center: new google.maps.LatLng(41.9000, 12.500),
@@ -74,9 +78,15 @@
               '</tr>';
             for (var j in _site.sliver_tools) {
               var sliver_tool = _site.sliver_tools[j];
+
               var status = sliver_tool.status;
-              statusCount[status] += 1;
-              sliverCount += 1;
+
+              // Only include production servers in the status count
+              if (isProductionServer(sliver_tool.server_id)) {
+                statusCount[status] += 1;
+                sliverCount += 1;
+              }
+
               htmlSiteInfo += '<tr>' +
                 '<td>' + sliver_tool.slice_id + '</td>' +
                 '<td>' + sliver_tool.tool_id + '</td>' +


### PR DESCRIPTION
This fixes the map view so that non-production servers (namely mlab4
servers) do not count when calculating what color to paint a node on the
map. In other words, ignore offline mlab4 servers when deciding whether
to make the map point green, yellow, or red.