### PR TITLE
Fixing broken links

### DIFF
--- a/server/mlabns/templates/base.html
+++ b/server/mlabns/templates/base.html
@@ -93,12 +93,8 @@
 
       &nbsp;&nbsp;&nbsp;&nbsp;
 
-      <a href="http://www.measurementlab.net/content/about-measurement-lab"
-        class="footer">About M-Lab</a>
-
-      &nbsp;&nbsp;&nbsp;&nbsp;
-
-      <a href="http://www.measurementlab.net/usage" class="footer">Usage</a>
+      <a href="http://www.measurementlab.net/about" class="footer">About
+        M-Lab</a>
 
       &nbsp;&nbsp;&nbsp;&nbsp;
 
@@ -106,7 +102,7 @@
 
       &nbsp;&nbsp;&nbsp;&nbsp;
 
-      <a href="http://www.measurementlab.net/content/faq" class="footer">FAQ</a>
+      <a href="http://www.measurementlab.net/faq" class="footer">FAQ</a>
 
       &nbsp;&nbsp;&nbsp;&nbsp;
     </div>

--- a/server/mlabns/templates/map_view.html
+++ b/server/mlabns/templates/map_view.html
@@ -287,12 +287,8 @@
 
       &nbsp;&nbsp;&nbsp;&nbsp;
 
-      <a href="http://www.measurementlab.net/content/about-measurement-lab"
-        class="footer">About M-Lab</a>
-
-      &nbsp;&nbsp;&nbsp;&nbsp;
-
-      <a href="http://www.measurementlab.net/usage" class="footer">Usage</a>
+      <a href="http://www.measurementlab.net/about" class="footer">About
+        M-Lab</a>
 
       &nbsp;&nbsp;&nbsp;&nbsp;
 
@@ -300,7 +296,7 @@
 
       &nbsp;&nbsp;&nbsp;&nbsp;
 
-      <a href="http://www.measurementlab.net/content/faq" class="footer">FAQ</a>
+      <a href="http://www.measurementlab.net/faq" class="footer">FAQ</a>
 
       &nbsp;&nbsp;&nbsp;&nbsp;
     </div>

--- a/server/mlabns/util/constants.py
+++ b/server/mlabns/util/constants.py
@@ -37,8 +37,8 @@ UNKNOWN_CITY = 'Zion'
 
 # URL to the privacy doc. All requests to http://mlab-ns.appspot.com/privacy
 # will be redirected to this URL.
-PRIVACY_DOC_URL = 'http://goo.gl/X1X2V'
+PRIVACY_DOC_URL = 'https://docs.google.com/a/google.com/document/d/1yQp7CcZngY6AfndoxvIbz8MzxcO7MpjZaj_VGFWe6Mo/pub'
 
 # URL to the design doc. All requests to http://mlab-ns.appspot.com/docs will be
 # redirected to this URL.
-DESIGN_DOC_URL = 'http://goo.gl/TlNZ3'
+DESIGN_DOC_URL = 'https://docs.google.com/document/d/1eJhS75EZHDLmC6exggStr_b1euiR24_MVBJc1L6eH2c/view'


### PR DESCRIPTION
This fixes the broken links on the dashboard pages of mlab-ns and
also replaces some goo.gl links with their full URLs.