### PR TITLE
Updates resolver to use tool_address_family

### DIFF
--- a/server/mlabns/util/resolver.py
+++ b/server/mlabns/util/resolver.py
@@ -22,8 +22,8 @@ def _tool_properties_from_query(query):
     """
     tool_properties = tool_fetcher.ToolProperties(
         tool_id=query.tool_id, status=message.STATUS_ONLINE)
-    if query.address_family:
-        tool_properties.address_family = query.address_family
+    if query.tool_address_family:
+        tool_properties.address_family = query.tool_address_family
     return tool_properties
 
 


### PR DESCRIPTION
Changes the resolver to use the correct property of LookupQuery,
tool_address_family. Also expands unit tests to ensure that this
property is exercised and honored in lookups.