### PR TITLE
Removing 'echo' from the list of M-Lab tools because that service was…

### DIFF
--- a/server/mlabns/conf/tools.csv
+++ b/server/mlabns/conf/tools.csv
@@ -2,7 +2,6 @@ tool_id,slice_id,http_port,show_tool_extra
 ndt,iupui_ndt,7123,False
 mobiperf,michigan_1,,False
 npad,iupui_npad,8000,False
-echo,mlab_utility,,False
 ooni,mlab_ooni,,True
 glasnost,mpisws_broadband,19981,False
 neubot,mlab_neubot,8080,False


### PR DESCRIPTION
… retired