### PR TITLE
Fixes a regression in geo_options where we only returned 1 tool

### DIFF
--- a/server/mlabns/tests/test_resolver.py
+++ b/server/mlabns/tests/test_resolver.py
@@ -79,7 +79,7 @@ class ResolverTestCaseBase(unittest.TestCase):
 
         mock_fetch.assert_called_with(tool_properties_expected)
 
-    def assertQueryResultSingleToolWithRandomSelection(
+    def assertQueryResultSingleToolWithRandomChoice(
             self, query, mock_fetch_results, filtered_tool_candidates,
             tool_properties_expected):
         """Assert that the resolver result matches expected values.
@@ -107,6 +107,45 @@ class ResolverTestCaseBase(unittest.TestCase):
 
             query_results_expected = [
                 filtered_tool_candidates[random_winner_index]]
+            query_results_actual = self.resolver.answer_query(query)
+            self.assertSequenceEqual(query_results_expected,
+                                     query_results_actual)
+
+            # Make sure that the random selection was between the expected
+            # candidate tools, after any filtering
+            self.assertSequenceEqual(filtered_tool_candidates,
+                                     mock_random.call_args[0][0])
+
+        mock_fetch.assert_called_with(tool_properties_expected)
+
+    def assertQueryResultMultiToolWithRandomSample(
+            self, query, mock_fetch_results, filtered_tool_candidates,
+            sample_size, tool_properties_expected):
+        """Assert that the resolver result matches expected values.
+
+        Assert that calling resolver.answer_query finds a list of tool
+        candidates to return and then randomly selects a single tool as the
+        winner. Also asserts that the resolver fetched tools from the db using
+        the correct criteria.
+
+        Args:
+            query: LookupQuery instance based on the client's query.
+            mock_fetch_results: Mock results from querying the db.
+            filtered_tool_candidates: The expected candidate tools from which
+                the resolver will randomly pick a winner.
+            sample_size: The number of randomly selected elements expected in
+                the final result.
+            tool_properties_expected: Expected tool properties that resolver
+                used to retrieve tools from the db.
+        """
+        mock_fetch = tool_fetcher.ToolFetcher().fetch
+        mock_fetch.return_value = mock_fetch_results
+
+        # Mock out random behavior to allow deterministic test results
+        with mock.patch('random.sample') as mock_random:
+            mock_random.side_effect = lambda x, k: x[-k:]
+
+            query_results_expected = filtered_tool_candidates[-sample_size:]
             query_results_actual = self.resolver.answer_query(query)
             self.assertSequenceEqual(query_results_expected,
                                      query_results_actual)
@@ -328,8 +367,8 @@ class GeoResolverTestCase(ResolverTestCaseBase):
         tool_properties_expected = tool_fetcher.ToolProperties(
             tool_id=_TOOL_ID, status=message.STATUS_ONLINE)
 
-        self.assertQueryResultSingleToolWithRandomSelection(
-            query, mock_fetched_tools, filtered_tools_expected,
+        self.assertQueryResultMultiToolWithRandomSample(
+            query, mock_fetched_tools, filtered_tools_expected, 1,
             tool_properties_expected)
 
 
@@ -485,7 +524,8 @@ class GeoResolverWithOptionsTestCase(ResolverTestCaseBase):
         # Result should be None when there are no matches.
         self.assertIsNone(self.resolver.answer_query(query))
 
-    def testAnswerQueryReturnsRandomToolWhenQueryIsMissingLatLon(self):
+    def testAnswerQueryReturnsRandomSubsetWhenQueryIsMissingLatLon(self):
+        """When lat/lon is missing, expect a random subset of tools."""
         # TODO(mtlynch): This behavior is confusing because it is inconsistent
         # with the other resolvers that return None when required attributes are
         # missing from the query. Change so that all are consistent.
@@ -496,6 +536,12 @@ class GeoResolverWithOptionsTestCase(ResolverTestCaseBase):
             _createSliverTool(
                 _TOOL_ID, site_id='abc01', latitude=1.0, longitude=1.0),
             _createSliverTool(
+                _TOOL_ID, site_id='abc02', latitude=1.0, longitude=1.0),
+            _createSliverTool(
+                _TOOL_ID, site_id='abc03', latitude=1.0, longitude=1.0),
+            _createSliverTool(
+                _TOOL_ID, site_id='abc04', latitude=1.0, longitude=1.0),
+            _createSliverTool(
                 _TOOL_ID, site_id='cba01', latitude=5.0, longitude=5.0)]
 
         # When lat/lon is missing, resolver performs no additional filtering
@@ -505,8 +551,8 @@ class GeoResolverWithOptionsTestCase(ResolverTestCaseBase):
         tool_properties_expected = tool_fetcher.ToolProperties(
             tool_id=_TOOL_ID, status=message.STATUS_ONLINE)
 
-        self.assertQueryResultSingleToolWithRandomSelection(
-            query, mock_fetched_tools, filtered_tools_expected,
+        self.assertQueryResultMultiToolWithRandomSample(
+            query, mock_fetched_tools, filtered_tools_expected, 4,
             tool_properties_expected)
 
 
@@ -539,7 +585,7 @@ class RandomResolverTestCase(ResolverTestCaseBase):
             tool_id=_TOOL_ID, address_family=message.ADDRESS_FAMILY_IPv6,
             status=message.STATUS_ONLINE)
 
-        self.assertQueryResultSingleToolWithRandomSelection(
+        self.assertQueryResultSingleToolWithRandomChoice(
             query, mock_fetched_tools, filtered_tools_expected,
             tool_properties_expected)
 
@@ -598,7 +644,7 @@ class MetroResolverTestCase(ResolverTestCaseBase):
             tool_id=_TOOL_ID, status=message.STATUS_ONLINE,
             address_family=message.ADDRESS_FAMILY_IPv4, metro=query.metro)
 
-        self.assertQueryResultSingleToolWithRandomSelection(
+        self.assertQueryResultSingleToolWithRandomChoice(
             query, mock_fetched_tools, filtered_tools_expected,
             tool_properties_expected)
 
@@ -647,7 +693,7 @@ class CountryResolverTestCase(ResolverTestCaseBase):
             tool_id=_TOOL_ID, status=message.STATUS_ONLINE,
             address_family=message.ADDRESS_FAMILY_IPv4, country=country)
 
-        self.assertQueryResultSingleToolWithRandomSelection(
+        self.assertQueryResultSingleToolWithRandomChoice(
             query, mock_fetched_tools, filtered_tools_expected,
             tool_properties_expected)
 

--- a/server/mlabns/util/resolver.py
+++ b/server/mlabns/util/resolver.py
@@ -57,9 +57,6 @@ class GeoResolver(ResolverBase):
     def _get_closest_n_candidates(self, query, max_results):
         """Selects the top N geographically closest SliverTools to the client.
 
-        Finds the top N closest SliverTools to the client and returns them.
-        Note that N is currently hardcoded to 4.
-
         Args:
             query: A LookupQuery instance.
             max_results: The maximum number of candidates to return.
@@ -75,11 +72,7 @@ class GeoResolver(ResolverBase):
         if (query.latitude is None) or (query.longitude is None):
             logging.warning(
                 'No latitude/longitude, return random sliver tool(s).')
-            if len(candidates) <= max_results:
-                random.shuffle(candidates)
-                return candidates
-            else:
-                return random.sample(candidates, max_results)
+            return random.sample(candidates, min(len(candidates), max_results))
 
         # Pre-shuffle the candidates to randomize the order of equidistant
         # results.

--- a/server/mlabns/util/resolver.py
+++ b/server/mlabns/util/resolver.py
@@ -74,8 +74,12 @@ class GeoResolver(ResolverBase):
 
         if (query.latitude is None) or (query.longitude is None):
             logging.warning(
-                'No latitude/longitude, return a random sliver tool.')
-            return [random.choice(candidates)]
+                'No latitude/longitude, return random sliver tool(s).')
+            if len(candidates) <= max_results:
+                random.shuffle(candidates)
+                return candidates
+            else:
+                return random.sample(candidates, max_results)
 
         # Pre-shuffle the candidates to randomize the order of equidistant
         # results.


### PR DESCRIPTION
Fixes a regression in geo_options where if the lat/lon was missing from
the LookupQuery, the resolver would return a single random tool instead
of a random subset of tools (geo_options requests should yield a list).