### PR TITLE
Fixes lookup_query to explicitly set default value to None

### DIFF
--- a/server/mlabns/tests/test_lookup_query.py
+++ b/server/mlabns/tests/test_lookup_query.py
@@ -11,7 +11,7 @@ from mlabns.util import message
 
 class LookupQueryTestCase(unittest2.TestCase):
 
-    def mock_get(self, arg, default_value=None):
+    def mock_get(self, arg, default_value=''):
         """Mock method to replace the GAE get() API for web requests."""
         if arg in self.mock_query_params:
             return self.mock_query_params[arg]

--- a/server/mlabns/util/lookup_query.py
+++ b/server/mlabns/util/lookup_query.py
@@ -97,7 +97,8 @@ class LookupQuery:
             self._ip_is_explicit = False
 
     def _set_tool_address_family(self, request):
-        tool_address_family = request.get(message.ADDRESS_FAMILY)
+        tool_address_family = request.get(message.ADDRESS_FAMILY,
+                                          default_value=None)
         valid_address_families = (message.ADDRESS_FAMILY_IPv4,
                                   message.ADDRESS_FAMILY_IPv6)
         if tool_address_family in valid_address_families:
@@ -105,8 +106,9 @@ class LookupQuery:
 
     def _set_geolocation(self, request):
         self._set_appengine_geolocation(request)
-        self._user_defined_city = request.get(message.CITY)
-        self.user_defined_country = request.get(message.COUNTRY)
+        self._user_defined_city = request.get(message.CITY, default_value=None)
+        self.user_defined_country = request.get(message.COUNTRY,
+                                                default_value=None)
         input_latitude, input_longitude = self._get_user_defined_lat_lon(
             request)
 
@@ -163,8 +165,8 @@ class LookupQuery:
         """
         MAX_LATITUDE_ABSOLUTE = 90.0
         MAX_LONGITUDE_ABSOLUTE = 180.0
-        input_latitude = request.get(message.LATITUDE)
-        input_longitude = request.get(message.LONGITUDE)
+        input_latitude = request.get(message.LATITUDE, default_value=None)
+        input_longitude = request.get(message.LONGITUDE, default_value=None)
 
         if not input_latitude or not input_longitude:
             return None, None


### PR DESCRIPTION
Fixes a regression in lookup_query where request.get calls were not
getting explicitly set to default_value=None.

Updates unit tests so that unit test mocks accurately mimic GAE's
request.get:
https://cloud.google.com/appengine/docs/python/tools/webapp/requestclass#Request_get