### PR TITLE
Filtering out non-production sites/slices

### DIFF
--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -12,6 +12,7 @@ import urllib2
 from mlabns.db import model
 from mlabns.util import constants
 from mlabns.util import message
+from mlabns.util import production_check
 from mlabns.util import util
 
 
@@ -47,7 +48,7 @@ class SiteRegistrationHandler(webapp.RequestHandler):
                               json.dumps(site), field)
                 return False
 
-        if not re.match(r'[a-z]{3}\d{2}', site[cls.SITE_FIELD]):
+        if not production_check.is_production_site(site[cls.SITE_FIELD]):
             logging.info('Ignoring non-production site: %s',
                          site[cls.SITE_FIELD])
             return False
@@ -199,6 +200,9 @@ class IPUpdateHandler(webapp.RequestHandler):
             fqdn = line_fields[0]
             ipv4 = line_fields[1]
             ipv6 = line_fields[2]
+
+            if not production_check.is_production_slice(fqdn):
+              continue
 
             sliver_tool_gql = model.SliverTool.gql('WHERE fqdn=:fqdn',
                                                    fqdn=fqdn)

--- a/server/mlabns/tests/test_production_check.py
+++ b/server/mlabns/tests/test_production_check.py
@@ -1,0 +1,45 @@
+import unittest
+
+from mlabns.util import production_check as pc
+
+
+class CheckProductionTestCase(unittest.TestCase):
+
+    def testIsProductionSite(self):
+        self.assertTrue(pc.is_production_site('nuq01'))
+        self.assertTrue(pc.is_production_site('nuq99'))
+        self.assertTrue(pc.is_production_site('tun05'))
+        self.assertTrue(
+            pc.is_production_site('TUN05'),
+            ('production style site names are considered production even when '
+             'uppercase'))
+
+        self.assertFalse(pc.is_production_site(''))
+        self.assertFalse(pc.is_production_site('foo'))
+        self.assertFalse(
+            pc.is_production_site('lga123'),
+            'Sites with too many numbers are not production sites.')
+        self.assertFalse(
+            pc.is_production_site('lga01t'),
+            'Sites with a t suffix are not production sites.')
+
+    def testIsProductionSlice(self):
+        self.assertTrue(pc.is_production_slice(
+            'ndt.iupui.mlab3.mad01.measurement-lab.org'))
+        self.assertTrue(pc.is_production_slice(
+            '1.michigan.mlab1.hnd01.measurement-lab.org'))
+        self.assertTrue(pc.is_production_slice(
+            'npad.iupui.mlab1.dfw05.measurement-lab.org'))
+        self.assertTrue(pc.is_production_slice(
+            'ooni.mlab.mlab1.ams02.measurement-lab.org'))
+
+        self.assertFalse(pc.is_production_slice(
+            'ndt.iupui.mlab4.prg01.measurement-lab.org'),
+            'mlab4 servers are not production slices')
+        self.assertFalse(pc.is_production_slice(
+            'ooni.mlab.mlab1.ams02t.measurement-lab.org'),
+            'sites with t suffix do not have production slices')
+        self.assertFalse(pc.is_production_slice('www.measurementlab.net'))
+        self.assertFalse(pc.is_production_slice('www.measurement-lab.org'))
+        self.assertFalse(pc.is_production_slice(''))
+        self.assertFalse(pc.is_production_slice('.'))

--- a/server/mlabns/util/production_check.py
+++ b/server/mlabns/util/production_check.py
@@ -1,0 +1,34 @@
+import re
+
+
+def is_production_site(site_name):
+    """Determines if the given site name matches the production site schema
+
+    Args:
+        site_name: Name of site to check (e.g. "lga01")
+
+    Returns:
+        True if the site name matches the schema of a production site.
+    """
+    return re.match('^[a-z]{3}\d{2}$', site_name, re.IGNORECASE) != None
+
+
+def is_production_slice(slice_fqdn):
+    """Determines if the given FQDN matches the schema for a production slice
+
+    Args:
+        slice_fqdn: Slice FQDN to check (e.g. "lga01")
+
+    Returns:
+        True if the slice FQDN matches the schema of a production slice.
+    """
+    fqdn_parts = slice_fqdn.split('.')
+    # Look for a production site name in the FQDN
+    for i in range(1, len(fqdn_parts)):
+        # If a production site name exists, the previous part of the FQDN will
+        # be the server ID. For example, in "mlab1.nuq02", nuq02 is the site
+        # name and mlab1 is the server ID.
+        if is_production_site(fqdn_parts[i]):
+            server_id = fqdn_parts[i - 1]
+            return re.match('^mlab[123]$', server_id, re.IGNORECASE) != None
+    return False

--- a/server/mlabns/util/production_check.py
+++ b/server/mlabns/util/production_check.py
@@ -17,7 +17,8 @@ def is_production_slice(slice_fqdn):
     """Determines if the given FQDN matches the schema for a production slice
 
     Args:
-        slice_fqdn: Slice FQDN to check (e.g. "lga01")
+        slice_fqdn: Slice FQDN to check (e.g.
+          "ndt.iupui.mlab3.mad01.measurement-lab.org")
 
     Returns:
         True if the slice FQDN matches the schema of a production slice.


### PR DESCRIPTION
This change adds more robust filtering to exclude non-production M-Lab
sites and slices from mlab-ns.

This fixes issue #36.