### PR TITLE
Adds support for NDT-SSL.

### DIFF
--- a/server/mlabns/conf/tools.csv
+++ b/server/mlabns/conf/tools.csv
@@ -1,6 +1,6 @@
 tool_id,slice_id,http_port,show_tool_extra
 ndt,iupui_ndt,7123,False
-ndt_ssl,iupui_ndt,7123,False
+ndt_ssl,iupui_ndt,,False
 mobiperf,michigan_1,,False
 npad,iupui_npad,8000,False
 ooni,mlab_ooni,,True

--- a/server/mlabns/conf/tools.csv
+++ b/server/mlabns/conf/tools.csv
@@ -1,5 +1,6 @@
 tool_id,slice_id,http_port,show_tool_extra
 ndt,iupui_ndt,7123,False
+ndt_ssl,iupui_ndt,7123,False
 mobiperf,michigan_1,,False
 npad,iupui_npad,8000,False
 ooni,mlab_ooni,,True

--- a/server/mlabns/tests/test_fqdn_rewrite.py
+++ b/server/mlabns/tests/test_fqdn_rewrite.py
@@ -1,0 +1,68 @@
+import unittest
+
+from mlabns.util import fqdn_rewrite
+from mlabns.util import message
+
+
+class FqdnRewriteTest(unittest.TestCase):
+
+    def testAfAgnosticNdtPlaintextFqdn(self):
+        """When there is no AF and tool is not NDT-SSL, don't rewrite."""
+        fqdn = 'ndt.iupui.mlab1.lga06.measurement-lab.org'
+        self.assertEqual(fqdn, fqdn_rewrite.rewrite(fqdn, None, 'ndt'))
+
+    def testIPv4NdtPlaintextFqdn(self):
+        """Add a v4 annotation for v4-specific requests."""
+        fqdn_original = 'ndt.iupui.mlab1.lga06.measurement-lab.org'
+        fqdn_expected = 'ndt.iupui.mlab1v4.lga06.measurement-lab.org'
+        fqdn_actual = fqdn_rewrite.rewrite(fqdn_original,
+                                           message.ADDRESS_FAMILY_IPv4, 'ndt')
+        self.assertEqual(fqdn_expected, fqdn_actual)
+
+    def testIPv6NdtPlaintextFqdn(self):
+        """Add a v6 annotation for v6-specific requests."""
+        fqdn_original = 'ndt.iupui.mlab1.lga06.measurement-lab.org'
+        fqdn_expected = 'ndt.iupui.mlab1v6.lga06.measurement-lab.org'
+        fqdn_actual = fqdn_rewrite.rewrite(fqdn_original,
+                                           message.ADDRESS_FAMILY_IPv6, 'ndt')
+        self.assertEqual(fqdn_expected, fqdn_actual)
+
+    def testAfAgnosticNdtSslFqdn(self):
+        """Convert dots to dashes, but omit AF annotation for NDT-SSL."""
+        fqdn_original = 'ndt.iupui.mlab1.lga06.measurement-lab.org'
+        fqdn_expected = 'ndt-iupui-mlab1-lga06.measurement-lab.org'
+        fqdn_actual = fqdn_rewrite.rewrite(fqdn_original, None, 'ndt_ssl')
+        self.assertEqual(fqdn_expected, fqdn_actual)
+
+    def testIPv4NdtSslFqdn(self):
+        """Add a v4 annotation and rewrite dots to dashes for NDT-SSL."""
+        fqdn_original = 'ndt.iupui.mlab1.lga06.measurement-lab.org'
+        fqdn_expected = 'ndt-iupui-mlab1v4-lga06.measurement-lab.org'
+        fqdn_actual = fqdn_rewrite.rewrite(
+            fqdn_original, message.ADDRESS_FAMILY_IPv4, 'ndt_ssl')
+        self.assertEqual(fqdn_expected, fqdn_actual)
+
+    def testIPv6NdtSslFqdn(self):
+        """Add a v6 annotation and rewrite dots to dashes for NDT-SSL."""
+        fqdn_original = 'ndt.iupui.mlab1.lga06.measurement-lab.org'
+        fqdn_expected = 'ndt-iupui-mlab1v6-lga06.measurement-lab.org'
+        fqdn_actual = fqdn_rewrite.rewrite(
+            fqdn_original, message.ADDRESS_FAMILY_IPv6, 'ndt_ssl')
+        self.assertEqual(fqdn_expected, fqdn_actual)
+
+    def testIPv6NpadFqdn(self):
+        """Add a v6 annotation for v6-specific requests for NPAD.
+
+        Note that all tools should behave identically except for ndt_ssl, so we
+        add this so we have confidence that we are treating ndt (NDT plaintext)
+        the same as other non-NDT tools.
+        """
+        fqdn_original = 'npad.iupui.mlab1.lga04.measurement-lab.org'
+        fqdn_expected = 'npad.iupui.mlab1v6.lga04.measurement-lab.org'
+        fqdn_actual = fqdn_rewrite.rewrite(fqdn_original,
+                                           message.ADDRESS_FAMILY_IPv6, 'npad')
+        self.assertEqual(fqdn_expected, fqdn_actual)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/server/mlabns/util/fqdn_rewrite.py
+++ b/server/mlabns/util/fqdn_rewrite.py
@@ -1,0 +1,102 @@
+"""Rewrites raw M-Lab FQDNs to apply post-processing or annotations."""
+
+import logging
+
+from mlabns.util import message
+
+
+def rewrite(fqdn, address_family, tool_id):
+    """Rewrites an FQDN to add necessary annotations and special-casing.
+
+    Performs the following rewrites on an FQDN:
+    * Adds a v4/v6 annotation if the client requested an explicit address family
+    * Applies a workaround to fix FQDNs for NDT-SSL queries.
+
+    Args:
+        fqdn: A tool FQDN with no address family specific annotation.
+        address_family: The address family for which to create the FQDN or None
+            to create an address family agnostic FQDN.
+        tool_id: Name of tool associated with the FQDN (e.g. 'ndt_ssl').
+
+    Returns:
+        FQDN after rewriting to apply all modifications to the raw FQDN.
+    """
+    rewritten_fqdn = _apply_af_awareness(fqdn, address_family)
+    rewritten_fqdn = _apply_ndt_ssl_workaround(rewritten_fqdn, tool_id)
+    return rewritten_fqdn
+
+
+def _apply_af_awareness(fqdn, address_family):
+    """Adds the v4/v6 only annotation to the fqdn.
+
+    Example:
+        fqdn:       'npad.iupui.mlab3.ath01.measurement-lab.org'
+        ipv4 only:  'npad.iupui.mlab3v4.ath01.measurement-lab.org'
+        ipv6 only:  'npad.iupui.mlab3v6.ath01.measurement-lab.org'
+
+    Args:
+        fqdn: A tool FQDN with no address family specific annotation.
+        address_family: The address family for which to create the FQDN or None
+            to create an address family agnostic FQDN.
+
+    Returns:
+        A FQDN specific to a particular address family, or the original FQDN
+        if an address family is not specified.
+    """
+    if not address_family:
+        fqdn_annotation = ''
+    elif address_family == message.ADDRESS_FAMILY_IPv4:
+        fqdn_annotation = 'v4'
+    elif address_family == message.ADDRESS_FAMILY_IPv6:
+        fqdn_annotation = 'v6'
+    else:
+        logging.error('Unrecognized address family: %s', address_family)
+        return fqdn
+
+    fqdn_parts = _split_fqdn(fqdn)
+    fqdn_parts[2] += fqdn_annotation
+
+    return '.'.join(fqdn_parts)
+
+
+def _apply_ndt_ssl_workaround(fqdn, tool_id):
+    """Rewrites ndt_ssl FQDNs to use dash separators for subdomains.
+
+    Rewrites ndt_ssl FQDNs to have proper formatting. Leaves FQDNs for all
+    other tools unmodified.
+
+    The NDT-SSL test uses dashes instead of dots as separators in the subdomain.
+    For example, instead of:
+        ndt.iupui.mlab1.lga06.measurement-lab.org
+    NDT-SSL uses:
+        ndt-iupui-mlab1-lga06.measurement-lab.org
+
+    The long term plan is to adjust all FQDNs to match this schema, but
+    currently Nagios (the source of mlab-ns' FQDN data) is not are not
+    aware of the dash-separator schema. We apply a special-case workaround here
+    so that we serve the correct FQDNs to clients for NDT-SSL queries until we
+    fix the naming in Nagios.
+
+    See https://github.com/m-lab/mlab-ns/issues/48 for more information.
+
+    Args:
+        fqdn: Tool's FQDN before any rewrites.
+        tool_id: Name of tool associated with the FQDN (e.g. 'ndt_ssl').
+
+    Returns:
+        FQDN with rewritten dashes if a rewrite was necessary, the original FQDN
+        otherwise.
+    """
+    # If this is not ndt_ssl, leave FQDN untouched.
+    if tool_id != 'ndt_ssl':
+        return fqdn
+    fqdn_parts = _split_fqdn(fqdn)
+
+    # Create subdomain like ndt-iupui-mlab1-lga06
+    subdomain = '-'.join(fqdn_parts[:-2])
+
+    return '.'.join((subdomain, fqdn_parts[-2], fqdn_parts[-1]))
+
+
+def _split_fqdn(fqdn):
+    return fqdn.split('.')


### PR DESCRIPTION
* Adds a special workaround for NDT-SSL as this tool is a special case
with respect to FQDNs. If the client queries for NDT-SSL, we first
convert the FQDN's subdomain to use dash separators rather than dot
separators (i.e. there is a single subdomain before the
measurement-lab.org portion of the FQDN). See #48 for more details.
* Adds an ndt_ssl tool to the tools config.

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/51)
<!-- Reviewable:end -->
