### PR TITLE
Fixes issue with sites missing in DS, and issue with one-sliver filter.

### DIFF
--- a/server/mlabns/db/sliver_tool_fetcher.py
+++ b/server/mlabns/db/sliver_tool_fetcher.py
@@ -226,7 +226,9 @@ class SliverToolFetcherDatastore(object):
         if tool_properties.status:
             results = _filter_by_status(results, tool_properties.address_family,
                                         tool_properties.status)
-        results = _filter_choose_one_host_per_site(results)
+
+        if not tool_properties.all_slivers:
+            results = _filter_choose_one_host_per_site(results)
 
         logging.info('%d sliver tools found in Datastore.', len(results))
         return results

--- a/server/mlabns/db/sliver_tool_fetcher.py
+++ b/server/mlabns/db/sliver_tool_fetcher.py
@@ -96,11 +96,13 @@ class ToolProperties(object):
     def __init__(self,
                  tool_id,
                  status=None,
+                 all_slivers=None,
                  address_family=None,
                  metro=None,
                  country=None):
         self.tool_id = tool_id
         self.status = status
+        self.all_slivers = all_slivers
         self.address_family = address_family
         self.metro = metro
         self.country = country
@@ -166,14 +168,16 @@ class SliverToolFetcherMemcache(object):
             # Can't filter by metro without hitting the Datastore because
             # Memcache does not have metro -> site ID mapping.
             return []
-        tool_filters.append(_filter_choose_one_host_per_site)
+
+        if not tool_properties.all_slivers:
+            tool_filters.append(_filter_choose_one_host_per_site)
 
         sliver_tools = memcache.get(
             tool_properties.tool_id,
             namespace=constants.MEMCACHE_NAMESPACE_TOOLS)
         if sliver_tools:
-            logging.info('Sliver tools found in memcache (%d results).',
-                         len(sliver_tools))
+            logging.info('{}: {} sliver tools found in memcache.'.format(
+                tool_properties.tool_id, len(sliver_tools)))
 
             candidates = sliver_tools
             for tool_filter in tool_filters:


### PR DESCRIPTION
Recently it was noticed that mlab-ns was not returning any entries for site SEA01, and instead was returning a 404. Yet, mlab2.sea01 was fully functional and being monitored and reported by Nagios. Digging into this issue revealed a couple of probable bugs in mlab-ns, which this PR aims to correct.

### First issue
The SliverToolFetcher was [filtering **all** requests](https://github.com/m-lab/mlab-ns/blob/master/server/mlabns/db/sliver_tool_fetcher.py#L169) down to [a single node](https://github.com/m-lab/mlab-ns/blob/master/server/mlabns/db/sliver_tool_fetcher.py#L225), regardless of the purpose of the request for records.  In the case of a tool client looking for a sliver to test against this is desired behavior. In the case of the [update handlers](https://github.com/m-lab/mlab-ns/blob/master/server/mlabns/handlers/update.py#L174) which [update the datastore and memcache](https://github.com/m-lab/mlab-ns/blob/master/server/mlabns/handlers/update.py#L315) from Nagios input, this is highly undesirable, since we want records for **all** slivers updated, not just the mlab1s at every site.

The practical outcome of this bug has (probably) been that under most circumstances **only** mlab1s have been updated based on Nagios status ([since the one-host code was implemented](https://github.com/m-lab/mlab-ns/pull/43)). Thankfully, since we rely _almost_ exclusively on mlab1s, this has been fine. However, there are some cases where mlab1s have had hardware problems and we have had to fall back on working mlab2s at a site. In these cases, the data from the mlab2 was possibly out of date. For example, Nagios may have flagged the mlab2 as down, but mlab-ns would not have picked that up. If you look in the datastore GAE for mlab-ns you will see that most mlab2s, mlab3s, etc. have not been updated for over a year.

This is potentially somewhat of a disaster, though likely mitigated by the fact that mlab1s are generally working, because if an mlab1 goes down for period and Nagios marked it as down, mlab-ns would fall back to the mlab2 at that site, using a Nagios status which was potentially a year or more stale. In those cases, we can only hope that the mlab2 was actually running.

The fix in this PR is to add a new `all_slivers` property to the `ToolProperties` class which can be set to `True` by the update handlers when all slivers need to be returned (none filtered). Since the default for `all_slivers` is `None`, existing queries from clients will still get only one node returned. For the update routines, they will pass `all_slivers=True`, causing the SliverToolFetchers to _not_ filter to a single node, meaning that all slivers can be updated based on Nagios status.

### Second issue
If a sliver did not already exist in the datastore, it would likely never get added. [The current code has logic](https://github.com/m-lab/mlab-ns/blob/master/server/mlabns/handlers/update.py#L210) that assumes that a GQL query on the datastore will return an object or value of `None` type if no records are found. However, this apparently seems to not be true, since if no record is found than an empty `_QueryIterator` object is returned. The `for` loop then has nothing to iterate on, and so is passed over. The problem is that it is that very `for` loop in which slivers missing from the datastore got added (based on the content of `mlab-host-ips.txt`. 

The fix in the PR is to actually count the amount of records returned by the GQL query. If some records are returned, checks are made on those records to make sure they are up to date. If no records are returned, the the `sliver_tool` is queued to be added to the datastore.

This PR also removes some superfluous logging, which was overly verbose and made debugging more difficult, since one had to wade through pages and pages of meaningless log message to find the ones that mattered.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/95)
<!-- Reviewable:end -->
