### PR TITLE
Increases instances classes for both live and testing to F4 (512MB RAM)

### DIFF
--- a/server/app.yaml.live
+++ b/server/app.yaml.live
@@ -3,6 +3,7 @@ version: 1
 runtime: python27
 api_version: 1
 threadsafe: false
+instance_class: F4
 
 handlers:
 

--- a/server/app.yaml.testing
+++ b/server/app.yaml.testing
@@ -3,6 +3,7 @@ version: 1
 runtime: python27
 api_version: 1
 threadsafe: false
+instance_class: F4
 
 handlers:
 


### PR DESCRIPTION
Now that the check_ip cron job is actually doing what it is supposed to be doing, it is using a lot more memory, and we are running into soft memory limit errors like:

> Exceeded soft private memory limit of 256 MB with 256 MB after servicing 2876 requests total

> After handling this request, the process that handled this request was found to be using too much memory and was terminated. This is likely to cause a new process to be used for the next request to your application. If you see this message frequently, you may have a memory leak in your application.

This PR bumps the GAE instance class for mlab-ns and mlab-nstesting [from the F2 to F4](https://cloud.google.com/appengine/docs/standard/#instance_classes).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/98)
<!-- Reviewable:end -->
