### PR TITLE
Sets a slivertool to offline if it exists in memcache, but not in Nagios.

### DIFF
--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -377,44 +377,45 @@ class StatusUpdateHandler(webapp.RequestHandler):
         updated_sliver_tools = []
         for sliver_tool in sliver_tools:
 
-            if sliver_tool.fqdn not in slice_status:
-                logging.info('Nagios does not know sliver %s.',
-                             sliver_tool.fqdn)
-                continue
-
-            if family == '':
-                if sliver_tool.sliver_ipv4 == message.NO_IP_ADDRESS:
-                    if sliver_tool.status_ipv4 == message.STATUS_ONLINE:
-                        logging.warning('Setting IPv4 status of %s to offline '\
-                                        'due to missing IP.', sliver_tool.fqdn)
-                        sliver_tool.status_ipv4 = message.STATUS_OFFLINE
+            if sliver_tool.fqdn in slice_status:
+                if family == '':
+                    if sliver_tool.sliver_ipv4 == message.NO_IP_ADDRESS:
+                        if sliver_tool.status_ipv4 == message.STATUS_ONLINE:
+                            logging.warning('Setting IPv4 status of %s to offline '\
+                                            'due to missing IP.', sliver_tool.fqdn)
+                            sliver_tool.status_ipv4 = message.STATUS_OFFLINE
+                    else:
+                        if (sliver_tool.status_ipv4 !=
+                                slice_status[sliver_tool.fqdn]['status'] or
+                                sliver_tool.tool_extra !=
+                                slice_status[sliver_tool.fqdn]['tool_extra']):
+                            sliver_tool.status_ipv4 = \
+                              slice_status[sliver_tool.fqdn]['status']
+                            sliver_tool.tool_extra = \
+                              slice_status[sliver_tool.fqdn]['tool_extra']
+                elif family == '_ipv6':
+                    if sliver_tool.sliver_ipv6 == message.NO_IP_ADDRESS:
+                        if sliver_tool.status_ipv6 == message.STATUS_ONLINE:
+                            logging.warning('Setting IPv6 status for %s to offline'\
+                                            ' due to missing IP.', sliver_tool.fqdn)
+                            sliver_tool.status_ipv6 = message.STATUS_OFFLINE
+                    else:
+                        if (sliver_tool.status_ipv6 !=
+                                slice_status[sliver_tool.fqdn]['status'] or
+                                sliver_tool.tool_extra !=
+                                slice_status[sliver_tool.fqdn]['tool_extra']):
+                            sliver_tool.status_ipv6 = \
+                              slice_status[sliver_tool.fqdn]['status']
+                            sliver_tool.tool_extra = \
+                              slice_status[sliver_tool.fqdn]['tool_extra']
                 else:
-                    if (sliver_tool.status_ipv4 !=
-                            slice_status[sliver_tool.fqdn]['status'] or
-                            sliver_tool.tool_extra !=
-                            slice_status[sliver_tool.fqdn]['tool_extra']):
-                        sliver_tool.status_ipv4 = \
-                          slice_status[sliver_tool.fqdn]['status']
-                        sliver_tool.tool_extra = \
-                          slice_status[sliver_tool.fqdn]['tool_extra']
-            elif family == '_ipv6':
-                if sliver_tool.sliver_ipv6 == message.NO_IP_ADDRESS:
-                    if sliver_tool.status_ipv6 == message.STATUS_ONLINE:
-                        logging.warning('Setting IPv6 status for %s to offline'\
-                                        ' due to missing IP.', sliver_tool.fqdn)
-                        sliver_tool.status_ipv6 = message.STATUS_OFFLINE
-                else:
-                    if (sliver_tool.status_ipv6 !=
-                            slice_status[sliver_tool.fqdn]['status'] or
-                            sliver_tool.tool_extra !=
-                            slice_status[sliver_tool.fqdn]['tool_extra']):
-                        sliver_tool.status_ipv6 = \
-                          slice_status[sliver_tool.fqdn]['status']
-                        sliver_tool.tool_extra = \
-                          slice_status[sliver_tool.fqdn]['tool_extra']
+                    logging.error('Unexpected address family: %s.', family)
+                    continue
             else:
-                logging.error('Unexpected address family: %s.', family)
-                continue
+                logging.info('Nagios does not know sliver %s. Taking it'\
+                             ' offline.', sliver_tool.fqdn)
+                sliver_tool.status_ipv4 = message.STATUS_OFFLINE
+                sliver_tool.status_ipv6 = message.STATUS_OFFLINE
 
             sliver_tool.update_request_timestamp = long(time.time())
             updated_sliver_tools.append(sliver_tool)


### PR DESCRIPTION
A small bug in mlab-ns was uncovered by a mistake I made when [decommissioning several sites](https://github.com/m-lab/operator/pull/143). I removed the sites from sites.py and Nagios without first having put them in lame-duck mode. The end result was that memcache in mlab-ns had correctly had the entries for these sites removed, but the datastore still had records for the removed sites, and worse had them marked as "online".

The problem was that when a query comes into mlab-ns and it cannot find a result in memcache, it will fall back to looking for something in the datastore. And in this case, the datastore had old/bad data for a site that no longer existed.

This problem would have been mitigated by my having put the nodes at these sites into lame-duck mode before removing them from Nagios and sites.py. The old entries in the datastore would still have been there, but they would have at least been marked as offline, and thus benign.

This PR implements yet one further safeguard against this sort of problem happening again. It adds some logic wherein if the routine (run once a minute) finds that it knows about a slivertool that for some reason is now not showing up in Nagios (baseList.pl), it will mark that slivertool as offline.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/102)
<!-- Reviewable:end -->
