### PR TITLE
removes a couple trailing references to glasnost

### DIFF
--- a/server/mlabns/handlers/admin.py
+++ b/server/mlabns/handlers/admin.py
@@ -26,8 +26,6 @@ class AdminHandler(webapp.RequestHandler):
             '/admin/map': lambda: self.redirect('/admin/map/ipv4/all'),
             '/admin/map/ipv4': lambda: self.redirect('/admin/map/ipv4/all'),
             '/admin/map/ipv4/all': lambda: self.map_view('all', 'ipv4'),
-            '/admin/map/ipv4/glasnost':
-            lambda: self.map_view('glasnost', 'ipv4'),
             '/admin/map/ipv4/mobiperf':
             lambda: self.map_view('mobiperf', 'ipv4'),
             '/admin/map/ipv4/neubot': lambda: self.map_view('neubot', 'ipv4'),
@@ -35,8 +33,6 @@ class AdminHandler(webapp.RequestHandler):
             '/admin/map/ipv4/npad': lambda: self.map_view('npad', 'ipv4'),
             '/admin/map/ipv6': lambda: self.map_view('all', 'ipv6'),
             '/admin/map/ipv6/all': lambda: self.map_view('all', 'ipv6'),
-            '/admin/map/ipv6/glasnost':
-            lambda: self.map_view('glasnost', 'ipv6'),
             '/admin/map/ipv6/mobiperf':
             lambda: self.map_view('mobiperf', 'ipv6'),
             '/admin/map/ipv6/neubot': lambda: self.map_view('neubot', 'ipv6'),

--- a/server/mlabns/templates/base.html
+++ b/server/mlabns/templates/base.html
@@ -3,7 +3,7 @@
             rel="stylesheet"
             href="/stylesheets/main.css" />
 
-    <title>{% block title %}mlab-ns (MLab Naming Service){% endblock %}
+    <title>{% block title %}mlab-ns (M-Lab Naming Service){% endblock %}
     </title>
 </head>
 
@@ -45,7 +45,6 @@
                     <a  href="/admin/map/ipv4"
                         class="header">Map IPv4</a>
                     <ul>
-                        <li><a href="/admin/map/ipv4/glasnost">Glasnost</a></li>
                         <li><a href="/admin/map/ipv4/mobiperf">Mobiperf</a></li>
                         <li><a href="/admin/map/ipv4/ndt">Ndt</a></li>
                         <li><a href="/admin/map/ipv4/neubot">Neubot</a></li>
@@ -59,7 +58,6 @@
                     <a  href="/admin/map/ipv6"
                         class="header">Map IPv6</a>
                     <ul>
-                        <li><a href="/admin/map/ipv6/glasnost">Glasnost</a></li>
                         <li><a href="/admin/map/ipv6/mobiperf">Mobiperf</a></li>
                         <li><a href="/admin/map/ipv6/ndt">Ndt</a></li>
                         <li><a href="/admin/map/ipv6/neubot">Neubot</a></li>
@@ -89,20 +87,20 @@
 
       &nbsp;&nbsp;&nbsp;&nbsp;
 
-      <a href="http://measurementlab.net" class="footer">M-Lab</a>
+      <a href="https://measurementlab.net" class="footer">M-Lab</a>
 
       &nbsp;&nbsp;&nbsp;&nbsp;
 
-      <a href="http://www.measurementlab.net/about" class="footer">About
+      <a href="https://www.measurementlab.net/about" class="footer">About
         M-Lab</a>
 
       &nbsp;&nbsp;&nbsp;&nbsp;
 
-      <a href="http://www.measurementlab.net/contact" class="footer">Contact</a>
+      <a href="https://www.measurementlab.net/contact" class="footer">Contact</a>
 
       &nbsp;&nbsp;&nbsp;&nbsp;
 
-      <a href="http://www.measurementlab.net/faq" class="footer">FAQ</a>
+      <a href="https://www.measurementlab.net/faq" class="footer">FAQ</a>
 
       &nbsp;&nbsp;&nbsp;&nbsp;
     </div>


### PR DESCRIPTION
This PR removes a couple of references to Glasnost remaining in the UI. Also makes a few URLs https.

@rschulman Would you have a moment to review?

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/112)
<!-- Reviewable:end -->
