### PR TITLE
Allows service status checks to use data from Prometheus, or Nagios.

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,7 +58,7 @@ To deploy mlab-ns in a fresh GCP project, it is necessary to first deploy the co
 
 Note: These instructions require billing to be enabled on your GCP project, as the data population process will exhaust a free-tiered project's daily AppEngine quota.
 
-Note: These instructions require you to have `nagios.csv`, which is not under source control as it contains secret credentials, but is available to authorized users here: https://goo.gl/tfEg1v.
+Note: These instructions require you to have files named `nagios.csv` and `prometheus.csv`, which are not under source control as they contains secret credentials, but is available to authorized users here: https://goo.gl/tfEg1v. Manually create those two files and paste the file content found at that URL into the files before running the `appcfg.py` commands below.
 
 ```
 # Replace URL with other project's URL if not populating mlab-nstesting
@@ -73,6 +73,11 @@ appcfg.py --url ${GAE_URL}/_ah/remote_api upload_data \
   --config_file=server/bulkloader.yaml \
   --filename=server/mlabns/conf/nagios.csv \
   --kind=Nagios
+
+appcfg.py --url ${GAE_URL}/_ah/remote_api upload_data \
+  --config_file=server/bulkloader.yaml \
+  --filename=server/mlabns/conf/prometheus.csv \
+  --kind=Prometheus
 ```
 
 Note: If you see repeated errors including `Refreshing due to a 401 (attempt

--- a/server/bulkloader.yaml
+++ b/server/bulkloader.yaml
@@ -228,6 +228,9 @@ transformers:
     - property: http_port
       external_name: http_port
 
+    - property: source
+      external_name: source
+
     - property: show_tool_extra
       external_name: show_tool_extra
       import_transform: transform.regexp_bool('true', re.IGNORECASE)

--- a/server/bulkloader.yaml
+++ b/server/bulkloader.yaml
@@ -95,6 +95,26 @@ transformers:
       external_name: url
 
 
+- kind: Prometheus
+  connector: csv
+  connector_options:
+      encoding: utf-8
+  property_map:
+    - property: __key__
+      external_name: index
+      import_transform: "lambda x: 'default_prometheus'"
+      export_transform: transform.key_id_or_name_as_string
+
+    - property: username
+      external_name: username
+
+    - property: password
+      external_name: password
+
+    - property: url
+      external_name: url
+
+
 - kind: Site
   connector: csv
   connector_options:

--- a/server/bulkloader.yaml
+++ b/server/bulkloader.yaml
@@ -102,7 +102,7 @@ transformers:
   property_map:
     - property: __key__
       external_name: index
-      import_transform: "lambda x: 'default_prometheus'"
+      import_transform: "lambda x: 'prometheus_default'"
       export_transform: transform.key_id_or_name_as_string
 
     - property: username

--- a/server/bulkloader.yaml
+++ b/server/bulkloader.yaml
@@ -228,8 +228,8 @@ transformers:
     - property: http_port
       external_name: http_port
 
-    - property: source
-      external_name: source
+    - property: status_source
+      external_name: status_source
 
     - property: show_tool_extra
       external_name: show_tool_extra

--- a/server/mlabns/conf/tools.csv
+++ b/server/mlabns/conf/tools.csv
@@ -1,4 +1,4 @@
-tool_id,slice_id,http_port,show_tool_extra,source
+tool_id,slice_id,http_port,show_tool_extra,status_source
 ndt,iupui_ndt,7123,False,nagios
 ndt_ssl,iupui_ndt,,False,nagios
 mobiperf,michigan_1,,False,nagios

--- a/server/mlabns/conf/tools.csv
+++ b/server/mlabns/conf/tools.csv
@@ -1,7 +1,7 @@
-tool_id,slice_id,http_port,show_tool_extra
-ndt,iupui_ndt,7123,False
-ndt_ssl,iupui_ndt,,False
-mobiperf,michigan_1,,False
-npad,iupui_npad,8000,False
-ooni,mlab_ooni,,True
-neubot,mlab_neubot,8080,False
+tool_id,slice_id,http_port,show_tool_extra,source
+ndt,iupui_ndt,7123,False,nagios
+ndt_ssl,iupui_ndt,,False,nagios
+mobiperf,michigan_1,,False,nagios
+npad,iupui_npad,8000,False,nagios
+ooni,mlab_ooni,,True,nagios
+neubot,mlab_neubot,8080,False,prometheus

--- a/server/mlabns/db/model.py
+++ b/server/mlabns/db/model.py
@@ -203,3 +203,21 @@ def get_all_tool_ids():
     for tool in Tool.all().run(batch_size=constants.GQL_BATCH_SIZE):
         tool_ids.append(tool.tool_id)
     return tool_ids
+
+
+def get_status_source_deps(source):
+    """Gets all Tools that rely on the given status source.
+
+    Args:
+        source: str, status source, either 'nagios or 'prometheus'.
+
+    Returns:
+        list, Tools that depend on `source`.
+    """
+    tools = []
+    tools_gql = Tool.gql("WHERE status_source = :source", source=source)
+    for tool in tools_gql.run():
+        tools.append(tool)
+    if not tools:
+        logging.info('No tools get their status from %s.', source)
+    return tools

--- a/server/mlabns/db/model.py
+++ b/server/mlabns/db/model.py
@@ -124,9 +124,17 @@ class Tool(db.Model):
     # redirected to: http://fqdn[ipv4|ipv6]:http_port
     http_port = db.StringProperty()
     show_tool_extra = db.BooleanProperty()
+    status_source = db.StringProperty()
 
 
 class Nagios(db.Model):
+    key_id = db.StringProperty()
+    username = db.StringProperty()
+    password = db.StringProperty()
+    url = db.StringProperty()
+
+
+class Prometheus(db.Model):
     key_id = db.StringProperty()
     username = db.StringProperty()
     password = db.StringProperty()

--- a/server/mlabns/db/prometheus_config_wrapper.py
+++ b/server/mlabns/db/prometheus_config_wrapper.py
@@ -1,0 +1,23 @@
+import logging
+
+from google.appengine.api import memcache
+
+from mlabns.db import model
+from mlabns.util import constants
+
+
+def get_prometheus_config():
+    """Retrieves Prometheus config info. First checks memcache, then datastore.
+
+    Returns:
+        Prometheus model instance
+    """
+    prometheus = memcache.get(constants.DEFAULT_PROMETHEUS_ENTRY)
+    if not prometheus:
+        prometheus = model.Prometheus.get_by_key_name(constants.DEFAULT_PROMETHEUS_ENTRY)
+        if prometheus:
+            memcache.set(constants.DEFAULT_PROMETHEUS_ENTRY, prometheus)
+        else:
+            logging.error('Datastore does not have the Prometheus credentials.')
+
+    return prometheus

--- a/server/mlabns/db/prometheus_config_wrapper.py
+++ b/server/mlabns/db/prometheus_config_wrapper.py
@@ -14,7 +14,8 @@ def get_prometheus_config():
     """
     prometheus = memcache.get(constants.DEFAULT_PROMETHEUS_ENTRY)
     if not prometheus:
-        prometheus = model.Prometheus.get_by_key_name(constants.DEFAULT_PROMETHEUS_ENTRY)
+        prometheus = model.Prometheus.get_by_key_name(
+            constants.DEFAULT_PROMETHEUS_ENTRY)
         if prometheus:
             memcache.set(constants.DEFAULT_PROMETHEUS_ENTRY, prometheus)
         else:

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -380,15 +380,15 @@ class StatusUpdateHandler(webapp.RequestHandler):
             tool = model.get_tool_from_tool_id(tool_id)
             for address_family in ['', '_ipv6']:
                 if tool.status_source == 'prometheus':
-                    logging.info('Status source for %s is: prometheus' %
-                                 tool_id)
+                    logging.info('Status source for %s%s is: prometheus' %
+                                 tool_id, address_family)
                     slice_info = prometheus_status.get_slice_info(
                         prometheus_config.url, tool_id, address_family)
-                    logging.warning('PROM URL: %s' % slice_info.slice_url)
                     slice_status = prometheus_status.get_slice_status(
                         slice_info.slice_url, prometheus_opener, tool.slice_id)
                 elif tool.status_source == 'nagios':
-                    logging.info('Status source for %s is: nagios' % tool_id)
+                    logging.info('Status source for %s%s is: nagios' % tool_id,
+                            address_family)
                     slice_info = nagios_status.get_slice_info(
                         nagios_config.url, tool_id, address_family)
                     slice_status = nagios_status.get_slice_status(

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -354,7 +354,6 @@ class StatusUpdateHandler(webapp.RequestHandler):
             logging.error('Datastore does not have the Prometheus configs.')
             return util.send_not_found(self)
         prometheus_opener = prometheus_status.authenticate_prometheus(prometheus_config)
-        logging.info('FIRST prometheus_config.url: %s' % prometheus_config.url)
 
         # Get Nagios configs, and authenticate.
         nagios_config = nagios_config_wrapper.get_nagios_config()
@@ -362,9 +361,6 @@ class StatusUpdateHandler(webapp.RequestHandler):
             logging.error('Datastore does not have the Nagios configs.')
             return util.send_not_found(self)
         nagios_opener = nagios_status.authenticate_nagios(nagios_config)
-        logging.info('nagios_config.url: %s' % nagios_config.url)
-
-        logging.info('SECOND prometheus_config.url: %s' % prometheus_config.url)
 
         for tool_id in model.get_all_tool_ids():
             tool = model.get_tool_from_tool_id(tool_id)

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -385,7 +385,7 @@ class StatusUpdateHandler(webapp.RequestHandler):
                     slice_info = prometheus_status.get_slice_info(
                         prometheus_config.url, tool_id, address_family)
                     slice_status = prometheus_status.get_slice_status(
-                        slice_info.slice_url, prometheus_opener, tool.slice_id)
+                        slice_info.slice_url, prometheus_opener)
                 elif tool.status_source == 'nagios':
                     logging.info('Status source for %s%s is: nagios' % tool_id,
                             address_family)

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -358,7 +358,7 @@ class StatusUpdateHandler(webapp.RequestHandler):
                         logging.error('Datastore does not have the Prometheus credentials.')
                         return util.send_not_found(self)
                     prometheus_status.authenticate_prometheus(prometheus)
-                    slice_info = prometheus_status.get_slice_info(prometheus.url, address_family)
+                    slice_info = prometheus_status.get_slice_info(prometheus.url, tool_id, address_family)
                     slice_status = prometheus_status.get_slice_status(
                             slice_info.slice_url, tool.slice_id)
                 elif tool.status_source == 'nagios':
@@ -368,7 +368,7 @@ class StatusUpdateHandler(webapp.RequestHandler):
                         logging.error('Datastore does not have the Nagios credentials.')
                         return util.send_not_found(self)
                     nagios_status.authenticate_nagios(nagios)
-                    slice_info = nagios_status.get_slice_info(nagios.url, address_family)
+                    slice_info = nagios_status.get_slice_info(nagios.url, tool_id, address_family)
                     slice_status = nagios_status.get_slice_status(slice_info.slice_url)
                 else:
                     logging.error('Unknown tool status_source: %s.', status_source)

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -368,12 +368,10 @@ class StatusUpdateHandler(webapp.RequestHandler):
                 if tool.status_source == 'prometheus':
                     logging.info('Status source for %s is: prometheus' % tool_id)
                     slice_info = prometheus_status.get_slice_info(prometheus_config.url, tool_id, address_family)
-                    logging.info('Status URL for %s is: %s' % (tool_id, slice_info.slice_url))
                     slice_status = prometheus_status.get_slice_status(slice_info.slice_url, prometheus_opener, tool.slice_id)
                 elif tool.status_source == 'nagios':
                     logging.info('Status source for %s is: nagios' % tool_id)
                     slice_info = nagios_status.get_slice_info(nagios_config.url, tool_id, address_family)
-                    logging.info('Status URL for %s is: %s' % (tool_id, slice_info.slice_url))
                     slice_status = nagios_status.get_slice_status(slice_info.slice_url, nagios_opener)
                 else:
                     logging.error('Unknown tool status_source: %s.', status_source)
@@ -402,7 +400,7 @@ class StatusUpdateHandler(webapp.RequestHandler):
         for sliver_tool in sliver_tools:
 
             if sliver_tool.fqdn not in slice_status:
-                logging.info('Prometheus does not know sliver %s.',
+                logging.info('Monitoring does not know sliver %s.',
                              sliver_tool.fqdn)
                 continue
 

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -388,6 +388,8 @@ class StatusUpdateHandler(webapp.RequestHandler):
                     if prometheus_config:
                         slice_info = prometheus_status.get_slice_info(
                             prometheus_config.url, tool_id, address_family)
+                        if not slice_info:
+                            continue
                         slice_status = prometheus_status.get_slice_status(
                             slice_info.slice_url, prometheus_opener)
                     else:

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -345,8 +345,8 @@ class StatusUpdateHandler(webapp.RequestHandler):
         """Triggers the update handler.
 
         Updates sliver status with information from either Nagios or Prometheus.
-        The URLs containing the information are stored in the datastore along
-        with the credentials necessary to access the data.
+        The base URLs for accessing status information are stored in the
+        datastore along with the credentials necessary to access the data.
         """
         # Get Prometheus configs, and authenticate.
         prometheus_config = prometheus_config_wrapper.get_prometheus_config()

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -371,9 +371,10 @@ class StatusUpdateHandler(webapp.RequestHandler):
         # of the configs is available, then abort, because we can't fetch status
         # from either. However, if we have one or the other, then continue,
         # because it may be preferable to update _some_ statuses than none.
-        if (prometheus_deps and not prometheus_config) and (nagios_deps and not
-                nagios_config):
-            logging.error('Neither Nagios nor Prometheus configs are available.')
+        if (prometheus_deps and not prometheus_config) and (nagios_deps and
+                                                            not nagios_config):
+            logging.error(
+                'Neither Nagios nor Prometheus configs are available.')
             return util.send_not_found(self)
 
         for tool_id in model.get_all_tool_ids():
@@ -381,14 +382,14 @@ class StatusUpdateHandler(webapp.RequestHandler):
             for address_family in ['', '_ipv6']:
                 if tool.status_source == 'prometheus':
                     logging.info('Status source for %s%s is: prometheus' %
-                                 tool_id, address_family)
+                                 (tool_id, address_family))
                     slice_info = prometheus_status.get_slice_info(
                         prometheus_config.url, tool_id, address_family)
                     slice_status = prometheus_status.get_slice_status(
                         slice_info.slice_url, prometheus_opener)
                 elif tool.status_source == 'nagios':
-                    logging.info('Status source for %s%s is: nagios' % tool_id,
-                            address_family)
+                    logging.info('Status source for %s%s is: nagios' %
+                                 (tool_id, address_family))
                     slice_info = nagios_status.get_slice_info(
                         nagios_config.url, tool_id, address_family)
                     slice_status = nagios_status.get_slice_status(

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -353,7 +353,8 @@ class StatusUpdateHandler(webapp.RequestHandler):
         if prometheus_config is None:
             logging.error('Datastore does not have the Prometheus configs.')
             return util.send_not_found(self)
-        prometheus_opener = prometheus_status.authenticate_prometheus(prometheus_config)
+        prometheus_opener = prometheus_status.authenticate_prometheus(
+            prometheus_config)
 
         # Get Nagios configs, and authenticate.
         nagios_config = nagios_config_wrapper.get_nagios_config()
@@ -366,20 +367,27 @@ class StatusUpdateHandler(webapp.RequestHandler):
             tool = model.get_tool_from_tool_id(tool_id)
             for address_family in ['', '_ipv6']:
                 if tool.status_source == 'prometheus':
-                    logging.info('Status source for %s is: prometheus' % tool_id)
-                    slice_info = prometheus_status.get_slice_info(prometheus_config.url, tool_id, address_family)
-                    slice_status = prometheus_status.get_slice_status(slice_info.slice_url, prometheus_opener, tool.slice_id)
+                    logging.info('Status source for %s is: prometheus' %
+                                 tool_id)
+                    slice_info = prometheus_status.get_slice_info(
+                        prometheus_config.url, tool_id, address_family)
+                    slice_status = prometheus_status.get_slice_status(
+                        slice_info.slice_url, prometheus_opener, tool.slice_id)
                 elif tool.status_source == 'nagios':
                     logging.info('Status source for %s is: nagios' % tool_id)
-                    slice_info = nagios_status.get_slice_info(nagios_config.url, tool_id, address_family)
-                    slice_status = nagios_status.get_slice_status(slice_info.slice_url, nagios_opener)
+                    slice_info = nagios_status.get_slice_info(
+                        nagios_config.url, tool_id, address_family)
+                    slice_status = nagios_status.get_slice_status(
+                        slice_info.slice_url, nagios_opener)
                 else:
-                    logging.error('Unknown tool status_source: %s.', status_source)
+                    logging.error('Unknown tool status_source: %s.',
+                                  status_source)
                     continue
 
                 if slice_status:
-                    self.update_sliver_tools_status(
-                        slice_status, slice_info.tool_id, slice_info.address_family)
+                    self.update_sliver_tools_status(slice_status,
+                                                    slice_info.tool_id,
+                                                    slice_info.address_family)
 
         return util.send_success(self)
 

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -381,7 +381,7 @@ class StatusUpdateHandler(webapp.RequestHandler):
                         slice_info.slice_url, nagios_opener)
                 else:
                     logging.error('Unknown tool status_source: %s.',
-                                  status_source)
+                                  tool.status_source)
                     continue
 
                 if slice_status:

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -356,7 +356,7 @@ class StatusUpdateHandler(webapp.RequestHandler):
                     logging.error('Datastore does not have the Prometheus credentials.')
                     return util.send_not_found(self)
                 prometheus_status.authenticate_prometheus(prometheus)
-                slice_info = prometheus_status.get_slice_info(prometheus.url):
+                slice_info = prometheus_status.get_slice_info(prometheus.url)
                 slice_status = prometheus_status.get_slice_status(
                         slice_info.slice_url, tool.slice_id)
             elif tool.status_source == 'nagios':
@@ -365,7 +365,7 @@ class StatusUpdateHandler(webapp.RequestHandler):
                     logging.error('Datastore does not have the Nagios credentials.')
                     return util.send_not_found(self)
                 nagios_status.authenticate_nagios(nagios)
-                slice_info = nagios_status.get_slice_info(nagios.url):
+                slice_info = nagios_status.get_slice_info(nagios.url)
                 slice_status = nagios_status.get_slice_status(slice_info.slice_url)
             else:
                 logging.error('Unknown tool status_source: %s.', status_source)

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -384,6 +384,7 @@ class StatusUpdateHandler(webapp.RequestHandler):
                                  tool_id)
                     slice_info = prometheus_status.get_slice_info(
                         prometheus_config.url, tool_id, address_family)
+                    logging.warning('PROM URL: %s' % slice_info.slice_url)
                     slice_status = prometheus_status.get_slice_status(
                         slice_info.slice_url, prometheus_opener, tool.slice_id)
                 elif tool.status_source == 'nagios':

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -368,12 +368,12 @@ class StatusUpdateHandler(webapp.RequestHandler):
                 if tool.status_source == 'prometheus':
                     logging.info('Status source for %s is: prometheus' % tool_id)
                     slice_info = prometheus_status.get_slice_info(prometheus_config.url, tool_id, address_family)
-                    logging.info('Status URL for % is: %s' % (tool_id, slice_info.slice_url))
+                    logging.info('Status URL for %s is: %s' % (tool_id, slice_info.slice_url))
                     slice_status = prometheus_status.get_slice_status(slice_info.slice_url, tool.slice_id)
                 elif tool.status_source == 'nagios':
                     logging.info('Status source for %s is: nagios' % tool_id)
                     slice_info = nagios_status.get_slice_info(nagios_config.url, tool_id, address_family)
-                    logging.info('Status URL for % is: %s' % (tool_id, slice_info.slice_url))
+                    logging.info('Status URL for %s is: %s' % (tool_id, slice_info.slice_url))
                     slice_status = nagios_status.get_slice_status(slice_info.slice_url)
                 else:
                     logging.error('Unknown tool status_source: %s.', status_source)

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -351,6 +351,7 @@ class StatusUpdateHandler(webapp.RequestHandler):
         for tool_id in model.get_all_tool_ids():
             tool = model.get_tool_from_tool_id(tool_id)
             if tool.status_source == 'prometheus':
+                logging.info('Status source for %s is: prometheus' % tool_id)
                 prometheus = prometheus_config_wrapper.get_prometheus_config()
                 if prometheus is None:
                     logging.error('Datastore does not have the Prometheus credentials.')
@@ -360,6 +361,7 @@ class StatusUpdateHandler(webapp.RequestHandler):
                 slice_status = prometheus_status.get_slice_status(
                         slice_info.slice_url, tool.slice_id)
             elif tool.status_source == 'nagios':
+                logging.info('Status source for %s is: nagios' % tool_id)
                 nagios = nagios_config_wrapper.get_nagios_config()
                 if nagios is None:
                     logging.error('Datastore does not have the Nagios credentials.')

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -381,19 +381,35 @@ class StatusUpdateHandler(webapp.RequestHandler):
             tool = model.get_tool_from_tool_id(tool_id)
             for address_family in ['', '_ipv6']:
                 if tool.status_source == 'prometheus':
-                    logging.info('Status source for %s%s is: prometheus' %
-                                 (tool_id, address_family))
-                    slice_info = prometheus_status.get_slice_info(
-                        prometheus_config.url, tool_id, address_family)
-                    slice_status = prometheus_status.get_slice_status(
-                        slice_info.slice_url, prometheus_opener)
+                    logging.info('Status source for %s%s is: prometheus',
+                                 tool_id, address_family)
+                    # Only proceed if prometheus_config exists, and hence
+                    # prometheus_opener should also exist.
+                    if prometheus_config:
+                        slice_info = prometheus_status.get_slice_info(
+                            prometheus_config.url, tool_id, address_family)
+                        slice_status = prometheus_status.get_slice_status(
+                            slice_info.slice_url, prometheus_opener)
+                    else:
+                        logging.error(
+                            'Prometheus config unavailable. Skipping %s%s',
+                            tool_id, address_family)
+                        continue
                 elif tool.status_source == 'nagios':
-                    logging.info('Status source for %s%s is: nagios' %
-                                 (tool_id, address_family))
-                    slice_info = nagios_status.get_slice_info(
-                        nagios_config.url, tool_id, address_family)
-                    slice_status = nagios_status.get_slice_status(
-                        slice_info.slice_url, nagios_opener)
+                    logging.info('Status source for %s%s is: nagios', tool_id,
+                                 address_family)
+                    # Only proceed if nagios_config exists, and hence
+                    # nagios_opener should also exist.
+                    if nagios_config:
+                        slice_info = nagios_status.get_slice_info(
+                            nagios_config.url, tool_id, address_family)
+                        slice_status = nagios_status.get_slice_status(
+                            slice_info.slice_url, nagios_opener)
+                    else:
+                        logging.error(
+                            'Nagios config unavailable. Skipping %s%s', tool_id,
+                            address_family)
+                        continue
                 else:
                     logging.error('Unknown tool status_source: %s.',
                                   tool.status_source)

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -357,7 +357,8 @@ class StatusUpdateHandler(webapp.RequestHandler):
                     return util.send_not_found(self)
                 prometheus_status.authenticate_prometheus(prometheus)
                 slice_info = prometheus_status.get_slice_info(prometheus.url):
-                slice_status = prometheus_status.get_slice_status(slice_info.slice_url)
+                slice_status = prometheus_status.get_slice_status(
+                        slice_info.slice_url, tool.slice_id)
             elif tool.status_source == 'nagios':
                 nagios = nagios_config_wrapper.get_nagios_config()
                 if nagios is None:

--- a/server/mlabns/tests/test_nagios_status.py
+++ b/server/mlabns/tests/test_nagios_status.py
@@ -2,7 +2,6 @@ import mock
 import unittest2
 import urllib2
 
-from mlabns.db import model
 from mlabns.handlers import update
 from mlabns.util import message
 from mlabns.util import nagios_status

--- a/server/mlabns/tests/test_nagios_status.py
+++ b/server/mlabns/tests/test_nagios_status.py
@@ -96,20 +96,24 @@ class GetSliceInfoTest(unittest2.TestCase):
         mock_tool_b_url_ipv6 = 'http://nagios.mock-mlab.net/baseList?show_state=1&service_name=mock_tool_b_ipv6&plugin_output=1'
         slice_data = {
             'mock_tool_a': {
-                'info': nagios_status.NagiosSliceInfo(mock_tool_a_url_ipv4, 'mock_tool_a', ''),
-                'info_ipv6': nagios_status.NagiosSliceInfo(mock_tool_a_url_ipv6, 'mock_tool_a', '_ipv6'),
+                'info': nagios_status.NagiosSliceInfo(mock_tool_a_url_ipv4,
+                                                      'mock_tool_a', ''),
+                'info_ipv6': nagios_status.NagiosSliceInfo(
+                    mock_tool_a_url_ipv6, 'mock_tool_a', '_ipv6'),
             },
             'mock_tool_b': {
-                'info': nagios_status.NagiosSliceInfo(mock_tool_b_url_ipv4, 'mock_tool_b', ''),
-                'info_ipv6': nagios_status.NagiosSliceInfo(mock_tool_b_url_ipv6, 'mock_tool_b', '_ipv6'),
+                'info': nagios_status.NagiosSliceInfo(mock_tool_b_url_ipv4,
+                                                      'mock_tool_b', ''),
+                'info_ipv6': nagios_status.NagiosSliceInfo(
+                    mock_tool_b_url_ipv6, 'mock_tool_b', '_ipv6'),
             }
-         }
+        }
 
         tool_ids = ['mock_tool_a', 'mock_tool_b']
         for tool_id in tool_ids:
             for address_family in ['', '_ipv6']:
                 retrieved = nagios_status.get_slice_info(
-                        self.nagios_base_url, tool_id, address_family)
+                    self.nagios_base_url, tool_id, address_family)
                 expected = slice_data[tool_id]['info' + address_family]
 
                 self.assertEqual(expected, retrieved)

--- a/server/mlabns/tests/test_prometheus_status.py
+++ b/server/mlabns/tests/test_prometheus_status.py
@@ -1,0 +1,169 @@
+import mock
+import unittest2
+import urllib
+import urllib2
+
+from mlabns.handlers import update
+from mlabns.util import constants
+from mlabns.util import message
+from mlabns.util import prometheus_status
+
+
+class ParseSliverToolStatusTest(unittest2.TestCase):
+
+    def test_parse_sliver_tool_status_returns_successfully_parsed_tuple(self):
+        status = {
+            "metric": {
+                "experiment": "ndt.iupui",
+                "machine": "mlab1.abc01.measurement-lab.org"
+            },
+            "value": [1522782427.81, "1"]
+        }
+        expected_parsed_status = ('ndt.iupui.mlab1.abc01.measurement-lab.org',
+                                  '1', constants.PROMETHEUS_TOOL_EXTRA)
+        actual_parsed_status = prometheus_status.parse_sliver_tool_status(
+            status)
+
+        self.assertTupleEqual(expected_parsed_status, actual_parsed_status)
+
+    def test_parse_sliver_tool_status_raises_PrometheusStatusUnparseableError_because_of_illformatted_status(
+            self):
+        status = 'mock status'
+
+        with self.assertRaises(
+                prometheus_status.PrometheusStatusUnparseableError):
+            prometheus_status.parse_sliver_tool_status(status)
+
+
+class GetSliceInfoTest(unittest2.TestCase):
+
+    def setUp(self):
+        self.prometheus_base_url = 'https://prometheus.mlab-oti.measurementlab.net/api/v1/query?query='
+
+    def test_get_slice_info_returns_none_with_nonexistent_tool(self):
+        retrieved = prometheus_status.get_slice_info(self.prometheus_base_url,
+                                                     'lol', '')
+        self.assertIsNone(retrieved)
+
+    def test_get_slice_info_returns_valid_objects_when_tools_stored(self):
+        ndt_url_ipv4 = self.prometheus_base_url + urllib.quote_plus(
+            prometheus_status.QUERIES['ndt'])
+        ndt_url_ipv6 = self.prometheus_base_url + urllib.quote_plus(
+            prometheus_status.QUERIES['ndt_ipv6'])
+        neubot_url_ipv4 = self.prometheus_base_url + urllib.quote_plus(
+            prometheus_status.QUERIES['neubot'])
+        neubot_url_ipv6 = self.prometheus_base_url + urllib.quote_plus(
+            prometheus_status.QUERIES['neubot_ipv6'])
+        slice_data = {
+            'ndt': {
+                'info':
+                prometheus_status.PrometheusSliceInfo(ndt_url_ipv4, 'ndt', ''),
+                'info_ipv6': prometheus_status.PrometheusSliceInfo(
+                    ndt_url_ipv6, 'ndt', '_ipv6'),
+            },
+            'neubot': {
+                'info': prometheus_status.PrometheusSliceInfo(neubot_url_ipv4,
+                                                              'neubot', ''),
+                'info_ipv6': prometheus_status.PrometheusSliceInfo(
+                    neubot_url_ipv6, 'neubot', '_ipv6'),
+            }
+        }
+
+        for tool_id in ['ndt', 'neubot']:
+            for address_family in ['', '_ipv6']:
+                retrieved = prometheus_status.get_slice_info(
+                    self.prometheus_base_url, tool_id, address_family)
+                expected = slice_data[tool_id]['info' + address_family]
+
+                self.assertEqual(expected, retrieved)
+
+
+class StatusUpdateHandlerTest(unittest2.TestCase):
+
+    def setUp(self):
+        self.status_update_handler = update.StatusUpdateHandler()
+        self.mock_urlopen_response = mock.Mock()
+        self.opener = urllib2.OpenerDirector()
+
+        urlopen_patch = mock.patch.object(
+            prometheus_status.urllib2.OpenerDirector,
+            'open',
+            return_value=self.mock_urlopen_response,
+            autospec=True)
+        self.addCleanup(urlopen_patch.stop)
+        urlopen_patch.start()
+
+        parse_sliver_tool_status_patch = mock.patch.object(
+            prometheus_status,
+            'parse_sliver_tool_status',
+            autospec=True)
+        self.addCleanup(parse_sliver_tool_status_patch.stop)
+        parse_sliver_tool_status_patch.start()
+
+    def test_get_slice_status_returns_none_with_invalid_json(self):
+        self.mock_urlopen_response.read.return_value = '{lol, not valid json'
+        result = prometheus_status.get_slice_status(
+            'prometheus.measurementlab.mock.net', self.opener)
+        self.assertIsNone(result)
+
+    def test_get_slice_status_returns_populated_dictionary_when_it_gets_valid_statuses(
+            self):
+        self.mock_urlopen_response.read.return_value = """
+        {
+            "status": "success",
+            "data": {
+                "resultType": "vector",
+                "result": [
+                    { "metric": {
+                          "experiment": "mock",
+                          "machine": "mlab1.xyz01.measurement-lab.org" },
+                      "value": [1522782427.81, "1"]
+                    },
+                    { "metric": {
+                          "experiment": "mock",
+                          "machine": "mlab2.xyz01.measurement-lab.org" },
+                      "value": [1522773427.51, "0"]
+                    }
+                ]
+            }
+        }"""
+        prometheus_status.parse_sliver_tool_status.side_effect = [
+            ('mock.mlab1.xyz01.measurement-lab.org', '1',
+             constants.PROMETHEUS_TOOL_EXTRA),
+            ('mock.mlab2.xyz01.measurement-lab.org', '0',
+             constants.PROMETHEUS_TOOL_EXTRA)
+        ]
+
+        expected_status = {
+            'mock.mlab1.xyz01.measurement-lab.org': {
+                'status': message.STATUS_ONLINE,
+                'tool_extra': constants.PROMETHEUS_TOOL_EXTRA
+            },
+            'mock.mlab2.xyz01.measurement-lab.org': {
+                'status': message.STATUS_OFFLINE,
+                'tool_extra': constants.PROMETHEUS_TOOL_EXTRA
+            }
+        }
+
+        actual_status = prometheus_status.get_slice_status(
+            'prometheus.measurementlab.mock.net', self.opener)
+        prometheus_status.urllib2.OpenerDirector.open.assert_called_once_with(
+            self.opener, 'prometheus.measurementlab.mock.net')
+        self.assertDictEqual(actual_status, expected_status)
+
+    def test_get_slice_status_returns_none_when_a_HTTPError_is_raised_by_urlopen(
+            self):
+
+        class MockHttpError(urllib2.HTTPError):
+
+            def __init__(self, cause):
+                self.cause = cause
+
+        self.mock_urlopen_response.read.side_effect = MockHttpError(
+            'mock http error')
+        self.assertIsNone(prometheus_status.get_slice_status(
+            'prometheus.measurementlab.mock.net', self.opener))
+
+
+if __name__ == '__main__':
+    unittest2.main()

--- a/server/mlabns/tests/test_prometheus_status.py
+++ b/server/mlabns/tests/test_prometheus_status.py
@@ -3,7 +3,6 @@ import unittest2
 import urllib
 import urllib2
 
-from mlabns.handlers import update
 from mlabns.util import constants
 from mlabns.util import message
 from mlabns.util import prometheus_status

--- a/server/mlabns/tests/test_prometheus_status.py
+++ b/server/mlabns/tests/test_prometheus_status.py
@@ -153,6 +153,8 @@ class StatusUpdateHandlerTest(unittest2.TestCase):
     def test_get_slice_status_returns_none_when_a_HTTPError_is_raised_by_urlopen(
             self, mock_open):
 
+        # urllib2.HTTPError() requires 6 arguments. Subclassing to override
+        # __init__ makes instantiating this easier.
         class MockHttpError(urllib2.HTTPError):
 
             def __init__(self, cause):

--- a/server/mlabns/util/constants.py
+++ b/server/mlabns/util/constants.py
@@ -2,6 +2,10 @@
 # configuration.
 DEFAULT_NAGIOS_ENTRY = 'default'
 
+# Name of the entry in the Prometheus table, containing the default
+# configuration.
+DEFAULT_PROMETHEUS_ENTRY = 'default'
+
 # Earth radius in km.
 EARTH_RADIUS = 6371
 
@@ -25,6 +29,11 @@ MEMCACHE_NAMESPACE_TOOLS = 'memcache_tools'
 # CRITICAL      2
 # UNKNOWN       3
 NAGIOS_SERVICE_STATUS_OK = '0'
+
+# Service state status values from Prometheus:
+# OK            1
+# CRITICAL      0
+PROMETHEUS_SERVICE_STATUS_OK = '1'
 
 # Maximum number of entities fetched from datastore in a single query.
 GQL_BATCH_SIZE = 1000

--- a/server/mlabns/util/constants.py
+++ b/server/mlabns/util/constants.py
@@ -4,7 +4,7 @@ DEFAULT_NAGIOS_ENTRY = 'default'
 
 # Name of the entry in the Prometheus table, containing the default
 # configuration.
-DEFAULT_PROMETHEUS_ENTRY = 'default'
+DEFAULT_PROMETHEUS_ENTRY = 'default_prometheus'
 
 # Earth radius in km.
 EARTH_RADIUS = 6371

--- a/server/mlabns/util/constants.py
+++ b/server/mlabns/util/constants.py
@@ -4,7 +4,7 @@ DEFAULT_NAGIOS_ENTRY = 'default'
 
 # Name of the entry in the Prometheus table, containing the default
 # configuration.
-DEFAULT_PROMETHEUS_ENTRY = 'default_prometheus'
+DEFAULT_PROMETHEUS_ENTRY = 'prometheus_default'
 
 # Earth radius in km.
 EARTH_RADIUS = 6371

--- a/server/mlabns/util/constants.py
+++ b/server/mlabns/util/constants.py
@@ -6,6 +6,12 @@ DEFAULT_NAGIOS_ENTRY = 'default'
 # configuration.
 DEFAULT_PROMETHEUS_ENTRY = 'prometheus_default'
 
+# String that the code will insert into SliverTool.tool_extra when the status
+# source in Prometheus. For Nagios, tool_extra comes from the Nagios plugin that
+# runs the check. This string for Prometheus is arbitrary and mostly used to
+# signal that the current status was set from Prometheus data.
+PROMETHEUS_TOOL_EXTRA = 'Prometheus was here \o/.'
+
 # Earth radius in km.
 EARTH_RADIUS = 6371
 

--- a/server/mlabns/util/nagios_status.py
+++ b/server/mlabns/util/nagios_status.py
@@ -103,24 +103,20 @@ def parse_sliver_tool_status(status):
     return sliver_fqdn, state, tool_extra
 
 
-def get_slice_info(nagios_base_url):
-    """Builds a list of NagiosSliceInfo objects to query Nagios for all slices.
+def get_slice_info(nagios_base_url, tool_id, address_family):
+    """Builds a NagiosSliceInfo object to query Nagios for a slice.
 
     Args:
         nagios_base_url: Base URL to get Nagios slice information.
+        tool_id: str, the name of the sliver tool.
+        address_family: str, empty for IPv4 or '_ipv6' for IPv6.
 
     Returns:
-         List of NagiosSliceInfo objects.
+         NagiosSliceInfo object.
     """
-    slice_objects = []
-    for tool_id in model.get_all_tool_ids():
-        for address_family in ['', '_ipv6']:
-            slice_url = (nagios_base_url + '?show_state=1&service_name=' +
-                         tool_id + address_family + "&plugin_output=1")
-            slice_objects.append(NagiosSliceInfo(slice_url, tool_id,
-                                                 address_family))
-
-    return slice_objects
+    slice_url = (nagios_base_url + '?show_state=1&service_name=' +
+                 tool_id + address_family + "&plugin_output=1")
+    return NagiosSliceInfo(slice_url, tool_id, address_family))
 
 
 def get_slice_status(url):

--- a/server/mlabns/util/nagios_status.py
+++ b/server/mlabns/util/nagios_status.py
@@ -116,7 +116,7 @@ def get_slice_info(nagios_base_url, tool_id, address_family):
     """
     slice_url = (nagios_base_url + '?show_state=1&service_name=' +
                  tool_id + address_family + "&plugin_output=1")
-    return NagiosSliceInfo(slice_url, tool_id, address_family))
+    return NagiosSliceInfo(slice_url, tool_id, address_family)
 
 
 def get_slice_status(url):

--- a/server/mlabns/util/nagios_status.py
+++ b/server/mlabns/util/nagios_status.py
@@ -2,7 +2,6 @@ import logging
 import re
 import urllib2
 
-from mlabns.db import model
 from mlabns.util import constants
 from mlabns.util import message
 

--- a/server/mlabns/util/nagios_status.py
+++ b/server/mlabns/util/nagios_status.py
@@ -117,8 +117,8 @@ def get_slice_info(nagios_base_url, tool_id, address_family):
     Returns:
          NagiosSliceInfo object.
     """
-    slice_url = (nagios_base_url + '?show_state=1&service_name=' +
-                 tool_id + address_family + "&plugin_output=1")
+    slice_url = (nagios_base_url + '?show_state=1&service_name=' + tool_id +
+                 address_family + "&plugin_output=1")
     return NagiosSliceInfo(slice_url, tool_id, address_family)
 
 

--- a/server/mlabns/util/nagios_status.py
+++ b/server/mlabns/util/nagios_status.py
@@ -60,6 +60,9 @@ def authenticate_nagios(nagios):
 
     Args:
         nagios: object containing Nagios auth information
+
+    Returns:
+        A urllib2 OpenerDirector object.
     """
     password_manager = urllib2.HTTPPasswordMgrWithDefaultRealm()
     password_manager.add_password(None, nagios.url, nagios.username,
@@ -67,7 +70,7 @@ def authenticate_nagios(nagios):
 
     authhandler = urllib2.HTTPDigestAuthHandler(password_manager)
     opener = urllib2.build_opener(authhandler)
-    urllib2.install_opener(opener)
+    return opener
 
 
 def parse_sliver_tool_status(status):
@@ -119,11 +122,12 @@ def get_slice_info(nagios_base_url, tool_id, address_family):
     return NagiosSliceInfo(slice_url, tool_id, address_family)
 
 
-def get_slice_status(url):
+def get_slice_status(url, opener):
     """Read slice status from Nagios.
 
     Args:
         url: String representing the URL to Nagios for a single slice.
+        opener: urllib2.OpenerDirector, opener authenticated with Nagios.
 
     Returns:
         A dict mapping sliver fqdn to a dictionary representing the sliver's
@@ -140,7 +144,7 @@ def get_slice_status(url):
     """
     status = {}
     try:
-        lines = urllib2.urlopen(url).read().strip('\n').split('\n')
+        lines = opener.open(url).read().strip('\n').split('\n')
     except urllib2.HTTPError:
         # TODO(claudiu) Notify(email) when this happens.
         logging.error('Cannot open %s.', url)

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -180,7 +180,7 @@ def get_slice_info(prometheus_base_url, tool_id, address_family):
     """
     tool_name = tool_id + address_family
     if not tool_name in QUERIES:
-        logging.error('There is no Prometheus query for tool: %s, tool_name')
+        logging.error('There is no Prometheus query for tool: %s', tool_name)
         return None
     query = urllib.quote_plus(QUERIES[tool_name])
     slice_url = prometheus_base_url + query

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -95,7 +95,7 @@ def parse_sliver_tool_status(status, slice_id):
     # Prometheus doesn't return any sort of "tool_extra" like baseList.pl does
     # for Nagios, so instead we drop in the timestamp returned by Prometheus,
     # just in case it could ever be useful.
-    tool_extra = status['value'][0]
+    tool_extra = str(status['value'][0])
 
     return sliver_fqdn, state, tool_extra
 

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -90,7 +90,7 @@ def parse_sliver_tool_status(status, slice_id):
 
     # Joins the experiment name with the machine name to form the FQDN fo the
     # experiment.
-    sliver_fqdn = experiment + status['metric']['machine']
+    sliver_fqdn = experiment + '.' + status['metric']['machine']
     state = status['value'][1]
     # Prometheus doesn't return any sort of "tool_extra" like baseList.pl does
     # for Nagios, so instead we drop in the timestamp returned by Prometheus,
@@ -201,7 +201,5 @@ def get_slice_status(url, opener, slice_id):
             results[sliver_fqdn]['status'] = message.STATUS_ONLINE
         else:
             results[sliver_fqdn]['status'] = message.STATUS_OFFLINE
-
-        logging.info('STATUS: %s: %s' % (sliver_fqdn, results[sliver_fqdn]))
 
     return results

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -119,40 +119,48 @@ def get_slice_info(prometheus_base_url, tool_id, address_family):
               script_success{service="ndt_e2e"} OR
               (vdlimit_used{experiment="ndt.iupui"} /
                   vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR
-              lame_duck_node{} != bool 1)"""),
+              lame_duck_experiment{} != bool 1)"""),
         'ndt_ipv6': textwrap.dedent("""\
             min by (experiment, machine) (
               probe_success{service="ndt_raw_ipv6"} OR
               script_success{service="ndt_e2e"} OR
               (vdlimit_used{experiment="ndt.iupui"} /
                   vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR
-              lame_duck_node{} != bool 1)"""),
+              lame_duck_experiment{} != bool 1)"""),
         'ndt_ssl': textwrap.dedent("""\
             min by (experiment, machine) (
               probe_success{service="ndt_ssl"} OR
               script_success{service="ndt_e2e"} OR
               (vdlimit_used{experiment="ndt.iupui"} /
                   vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR
-              lame_duck_node{} != bool 1)"""),
+              lame_duck_experiment{} != bool 1)"""),
         'ndt_ssl_ipv6': textwrap.dedent("""\
             min by (experiment, machine) (
               probe_success{service="ndt_ssl_ipv6"} OR
               script_success{service="ndt_e2e"} OR
               (vdlimit_used{experiment="ndt.iupui"} /
                   vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR
-              lame_duck_node{} != bool 1)"""),
-        'neubot': 'probe_success{service="neubot"}',
-        'neubot_ipv6': 'probe_success{service="neubot_ipv6"}',
+              lame_duck_experiment{} != bool 1)"""),
+        'neubot': textwrap.dedent("""\
+            min by (experiment, machine) (
+              probe_success{service="neubot"} OR
+              lame_duck_experiment{} != bool 1)"""),
+        'neubot_ipv6': textwrap.dedent("""\
+            min by (experiment, machine) (
+              probe_success{service="neubot_ipv6"} OR
+              lame_duck_experiment{} != bool 1)"""),
         'mobiperf': textwrap.dedent("""\
             min by (experiment, machine) (
               probe_success{service="mobiperf", instance=~".*:6001"} OR
               probe_success{service="mobiperf", instance=~".*:6002"} OR
-              probe_success{service="mobiperf", instance=~".*:6003"})"""),
+              probe_success{service="mobiperf", instance=~".*:6003"} OR
+              lame_duck_experiment{} != bool 1)"""),
         'mobiperf_ipv6': textwrap.dedent("""\
             min by (experiment, machine) (
               probe_success{service="mobiperf_ipv6", instance=~".*:6001"} OR
               probe_success{service="mobiperf_ipv6", instance=~".*:6002"} OR
-              probe_success{service="mobiperf_ipv6", instance=~".*:6003"})""")
+              probe_success{service="mobiperf_ipv6", instance=~".*:6003"} OR
+              lame_duck_experiment{} != bool 1)"""),
     }
 
     query = urllib.quote_plus(queries[tool_id + address_family])

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -120,7 +120,7 @@ def get_slice_info(prometheus_base_url, tool_id, address_family):
               script_success{service="ndt_e2e"} OR
               (vdlimit_used{experiment="ndt.iupui"} /
                   vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR
-              lame_duck_experiment{} != bool 1)
+              lame_duck_experiment{experiment="ndt.iupui"} != bool 1)
               """),
         'ndt_ipv6': textwrap.dedent("""\
             min by (experiment, machine) (
@@ -128,7 +128,7 @@ def get_slice_info(prometheus_base_url, tool_id, address_family):
               script_success{service="ndt_e2e"} OR
               (vdlimit_used{experiment="ndt.iupui"} /
                   vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR
-              lame_duck_experiment{} != bool 1)
+              lame_duck_experiment{experiment="ndt.iupui"} != bool 1)
               """),
         'ndt_ssl': textwrap.dedent("""\
             min by (experiment, machine) (
@@ -136,7 +136,7 @@ def get_slice_info(prometheus_base_url, tool_id, address_family):
               script_success{service="ndt_e2e"} OR
               (vdlimit_used{experiment="ndt.iupui"} /
                   vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR
-              lame_duck_experiment{} != bool 1)
+              lame_duck_experiment{experiment="ndt.iupui"} != bool 1)
               """),
         'ndt_ssl_ipv6': textwrap.dedent("""\
             min by (experiment, machine) (
@@ -144,31 +144,31 @@ def get_slice_info(prometheus_base_url, tool_id, address_family):
               script_success{service="ndt_e2e"} OR
               (vdlimit_used{experiment="ndt.iupui"} /
                   vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR
-              lame_duck_experiment{} != bool 1)
+              lame_duck_experiment{experiment="ndt.iupui"} != bool 1)
               """),
         'neubot': textwrap.dedent("""\
             min by (experiment, machine) (
               probe_success{service="neubot"} OR
-              lame_duck_experiment{} != bool 1)
+              lame_duck_experiment{experiment="neubot.mlab"} != bool 1)
               """),
         'neubot_ipv6': textwrap.dedent("""\
             min by (experiment, machine) (
               probe_success{service="neubot_ipv6"} OR
-              lame_duck_experiment{} != bool 1)
+              lame_duck_experiment{experiment="neubot.mlab"} != bool 1)
               """),
         'mobiperf': textwrap.dedent("""\
             min by (experiment, machine) (
               probe_success{service="mobiperf", instance=~".*:6001"} OR
               probe_success{service="mobiperf", instance=~".*:6002"} OR
               probe_success{service="mobiperf", instance=~".*:6003"} OR
-              lame_duck_experiment{} != bool 1)
+              lame_duck_experiment{experiment="1.michigan"} != bool 1)
               """),
         'mobiperf_ipv6': textwrap.dedent("""\
             min by (experiment, machine) (
               probe_success{service="mobiperf_ipv6", instance=~".*:6001"} OR
               probe_success{service="mobiperf_ipv6", instance=~".*:6002"} OR
               probe_success{service="mobiperf_ipv6", instance=~".*:6003"} OR
-              lame_duck_experiment{} != bool 1)
+              lame_duck_experiment{experiment="1.michigan"} != bool 1)
               """),
     }
 

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -202,6 +202,6 @@ def get_slice_status(url, opener, slice_id):
         else:
             results[sliver_fqdn]['status'] = message.STATUS_OFFLINE
 
-        logging.info('STATUS: %s' % results[sliver_fqdn])
+        logging.info('STATUS: %s: %s' % (sliver_fqdn, results[sliver_fqdn]))
 
     return results

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -95,7 +95,7 @@ def parse_sliver_tool_status(status, slice_id):
     # Prometheus doesn't return any sort of "tool_extra" like baseList.pl does
     # for Nagios, so instead we drop in the timestamp returned by Prometheus,
     # just in case it could ever be useful.
-    tool_extra = str(status['value'][0])
+    tool_extra = 'Prom evaluation time: %d' % status['value'][0]
 
     return sliver_fqdn, state, tool_extra
 

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -185,7 +185,7 @@ def get_slice_status(url, slice_id):
 
     if statuses['status'] == 'error':
         logging.info('Prometheus returned error "%s" for URL %s.'
-                     % (statuses['error'], url)
+                     % (statuses['error'], url))
         return None
 
     for status in statuses['data']['result']:

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -192,10 +192,13 @@ def get_slice_status(url, opener, slice_id):
         logging.error('Cannot open %s.', url)
         return None
 
-    statuses = json.loads(raw_data)
+    try:
+        statuses = json.loads(raw_data)
+    except ValueError:
+        logging.error('Unable to parse JSON from: %s' % url)
 
     if statuses['status'] == 'error':
-        logging.info('Prometheus returned error "%s" for URL %s.' %
+        logging.error('Prometheus returned error "%s" for URL %s.' %
                      (statuses['error'], url))
         return None
 

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -90,7 +90,7 @@ def parse_sliver_tool_status(status, slice_id):
 
     # Joins the experiment name with the machine name to form the FQDN fo the
     # experiment.
-    slice_fqdn = experiment + status['metric']['machine']
+    sliver_fqdn = experiment + status['metric']['machine']
     state = status['value'][1]
     # Prometheus doesn't return any sort of "tool_extra" like baseList.pl does
     # for Nagios, so instead we drop in the timestamp returned by Prometheus,

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -202,4 +202,6 @@ def get_slice_status(url, opener, slice_id):
         else:
             results[sliver_fqdn]['status'] = message.STATUS_OFFLINE
 
+        logging.info('STATUS: %s' % results[sliver_fqdn])
+
     return results

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -87,9 +87,12 @@ def parse_sliver_tool_status(status, slice_id):
     # Turns 'iupui_ndt' into 'ndt.iupui', for example.
     experiment = '.'.join(slice_id.split('_')[::-1])
 
-    # Joins the experiment name with the machine name to form the FQDN fo the
+    # Joins the experiment name with the machine name to form the FQDN of the
     # experiment.
     sliver_fqdn = experiment + '.' + status['metric']['machine']
+    # 'status' is a list with two items. The first item ([0]) is a timestamp
+    # marking the Prometheus evaluation time. The second, which is the one we
+    # want, is the binary status value of the service.
     state = status['value'][1]
     # Prometheus doesn't return any sort of "tool_extra" like baseList.pl does
     # for Nagios, so instead just drop in a note that this was processed from

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -1,5 +1,6 @@
 import json
 import logging
+import textwrap
 import urllib
 import urllib2
 
@@ -116,43 +117,46 @@ def get_slice_info(prometheus_base_url, tool_id, address_family):
     # This dict maps tool_ids to the corresponding Prometheus query that will
     # return the status for the tool.
     queries = {
-        'ndt': ('min by (machine) ( '
-                'probe_success{service="ndt_raw"} OR '
-                'script_success{service="ndt_e2e"} OR '
-                '(vdlimit_used{experiment="ndt.iupui"} / '
-                'vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR '
-                'lame_duck_node{} != bool 1)'),
-        'ndt_ipv6': ('min by (machine) ( '
-                     'probe_success{service="ndt_raw_ipv6"} OR '
-                     'script_success{service="ndt_e2e"} OR '
-                     '(vdlimit_used{experiment="ndt.iupui"} / '
-                     'vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR '
-                     'lame_duck_node{} != bool 1)'),
-        'ndt_ssl': ('min by (machine) ( '
-                    'probe_success{service="ndt_ssl"} OR '
-                    'script_success{service="ndt_e2e"} OR '
-                    '(vdlimit_used{experiment="ndt.iupui"} / '
-                    'vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR '
-                    'lame_duck_node{} != bool 1)'),
-        'ndt_ssl_ipv6':
-        ('min by (machine) ( '
-         'probe_success{service="ndt_ssl_ipv6"} OR '
-         'script_success{service="ndt_e2e"} OR '
-         '(vdlimit_used{experiment="ndt.iupui"} / '
-         'vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR '
-         'lame_duck_node{} != bool 1)'),
+        'ndt': textwrap.dedent("""\
+            min by (machine) (
+              probe_success{service="ndt_raw"} OR
+              script_success{service="ndt_e2e"} OR
+              (vdlimit_used{experiment="ndt.iupui"} /
+                  vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR
+              lame_duck_node{} != bool 1)"""),
+        'ndt_ipv6': textwrap.dedent("""\
+            min by (machine) (
+              probe_success{service="ndt_raw_ipv6"} OR
+              script_success{service="ndt_e2e"} OR
+              (vdlimit_used{experiment="ndt.iupui"} /
+                  vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR
+              lame_duck_node{} != bool 1)"""),
+        'ndt_ssl': textwrap.dedent("""\
+            min by (machine) (
+              probe_success{service="ndt_ssl"} OR
+              script_success{service="ndt_e2e"} OR
+              (vdlimit_used{experiment="ndt.iupui"} /
+                  vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR
+              lame_duck_node{} != bool 1)"""),
+        'ndt_ssl_ipv6': textwrap.dedent("""\
+            min by (machine) (
+              probe_success{service="ndt_ssl_ipv6"} OR
+              script_success{service="ndt_e2e"} OR
+              (vdlimit_used{experiment="ndt.iupui"} /
+                  vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR
+              lame_duck_node{} != bool 1)"""),
         'neubot': 'probe_success{service="neubot"}',
         'neubot_ipv6': 'probe_success{service="neubot_ipv6"}',
-        'mobiperf':
-        ('min by (machine) ( '
-         'probe_success{service="mobiperf", instance=~".*:6001"} OR '
-         'probe_success{service="mobiperf", instance=~".*:6002"} OR '
-         'probe_success{service="mobiperf", instance=~".*:6003"})'),
-        'mobiperf_ipv6':
-        ('min by (machine) ( '
-         'probe_success{service="mobiperf_ipv6", instance=~".*:6001"} OR '
-         'probe_success{service="mobiperf_ipv6", instance=~".*:6002"} OR '
-         'probe_success{service="mobiperf_ipv6", instance=~".*:6003"})')
+        'mobiperf': textwrap.dedent("""\
+            min by (machine) (
+              probe_success{service="mobiperf", instance=~".*:6001"} OR
+              probe_success{service="mobiperf", instance=~".*:6002"} OR
+              probe_success{service="mobiperf", instance=~".*:6003"})"""),
+        'mobiperf_ipv6': textwrap.dedent("""\
+            min by (machine) (
+              probe_success{service="mobiperf_ipv6", instance=~".*:6001"} OR
+              probe_success{service="mobiperf_ipv6", instance=~".*:6002"} OR
+              probe_success{service="mobiperf_ipv6", instance=~".*:6003"})""")
     }
 
     query = urllib.quote_plus(queries[tool_id + address_family])

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -207,12 +207,12 @@ def get_slice_status(url, opener):
     try:
         statuses = json.loads(raw_data)
     except ValueError:
-        logging.error('Unable to parse JSON from: %s' % url)
+        logging.error('Unable to parse JSON from: %s', url)
         return None
 
     if statuses['status'] == 'error':
-        logging.error('Prometheus returned error "%s" for URL %s.' %
-                      (statuses['error'], url))
+        logging.error('Prometheus returned error "%s" for URL %s.',
+                      statuses['error'], url)
         return None
 
     for status in statuses['data']['result']:

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -208,6 +208,7 @@ def get_slice_status(url, opener):
         statuses = json.loads(raw_data)
     except ValueError:
         logging.error('Unable to parse JSON from: %s' % url)
+        return None
 
     if statuses['status'] == 'error':
         logging.error('Prometheus returned error "%s" for URL %s.' %

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -97,14 +97,16 @@ def parse_sliver_tool_status(status, slice_id):
     return sliver_fqdn, state, tool_extra
 
 
-def get_slice_info(prometheus_base_url):
-    """Builds a list of PrometheusSliceInfo objects to query Prometheus for all slices.
+def get_slice_info(prometheus_base_url, tool_id, address_family):
+    """Builds a a PrometheusSliceInfo object to query Prometheus for a slice.
 
     Args:
         prometheus_base_url: Base URL to get Prometheus slice information.
+        tool_id: str, the name of the sliver tool.
+        address_family: str, empty for IPv4 or '_ipv6' for IPv6.
 
     Returns:
-         List of PrometheusSliceInfo objects.
+         A PrometheusSliceInfo object for a slice.
     """
     # This dict maps tool_ids to the corresponding Prometheus query that will
     # return the status for the tool.
@@ -143,15 +145,9 @@ def get_slice_info(prometheus_base_url):
         )
     }
 
-    slice_objects = []
-    for tool_id in model.get_all_tool_ids():
-        for address_family in ['', '_ipv6']:
-            query = urllib.quote_plus(queries[tool_id + address_family])
-            slice_url = prometheus_base_url + query
-            slice_objects.append(PrometheusSliceInfo(slice_url, tool_id,
-                                                     address_family))
-
-    return slice_objects
+    query = urllib.quote_plus(queries[tool_id + address_family])
+    slice_url = prometheus_base_url + query
+    return PrometheusSliceInfo(slice_url, tool_id, address_family))
 
 
 def get_slice_status(url, slice_id):

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -93,8 +93,8 @@ def parse_sliver_tool_status(status, slice_id):
     sliver_fqdn = experiment + '.' + status['metric']['machine']
     state = status['value'][1]
     # Prometheus doesn't return any sort of "tool_extra" like baseList.pl does
-    # for Nagios, so instead we drop in the timestamp returned by Prometheus,
-    # just in case it could ever be useful.
+    # for Nagios, so instead just drop in a note that this was processed from
+    # Prometheus data.
     tool_extra = 'Prometheus was here \o/.'
 
     return sliver_fqdn, state, tool_extra

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -95,7 +95,7 @@ def parse_sliver_tool_status(status, slice_id):
     # Prometheus doesn't return any sort of "tool_extra" like baseList.pl does
     # for Nagios, so instead we drop in the timestamp returned by Prometheus,
     # just in case it could ever be useful.
-    tool_extra = 'Prom evaluation time: %d' % status['value'][0]
+    tool_extra = 'Prometheus was here \o/.'
 
     return sliver_fqdn, state, tool_extra
 

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -1,10 +1,8 @@
 import json
 import logging
-import re
 import urllib
 import urllib2
 
-from mlabns.db import model
 from mlabns.util import constants
 from mlabns.util import message
 

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -90,7 +90,7 @@ def parse_sliver_tool_status(status, slice_id):
 
     # Joins the experiment name with the machine name to form the FQDN fo the
     # experiment.
-    slice_fqdn = '.'.join(experiment, status['metric']['machine'])
+    slice_fqdn = experiment + status['metric']['machine'])
     state = status['value'][1]
     # Prometheus doesn't return any sort of "tool_extra" like baseList.pl does
     # for Nagios, so instead we drop in the timestamp returned by Prometheus,

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -69,7 +69,7 @@ def authenticate_prometheus(prometheus):
     password_manager.add_password(None, prometheus.url, prometheus.username,
                                   prometheus.password)
 
-    authhandler = urllib2.HTTPDigestAuthHandler(password_manager)
+    authhandler = urllib2.HTTPBasicAuthHandler(password_manager)
     opener = urllib2.build_opener(authhandler)
     return opener
 

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -86,7 +86,8 @@ def parse_sliver_tool_status(status):
     """
     # Joins the experiment name with the machine name to form the FQDN of the
     # experiment.
-    sliver_fqdn = status['metric']['experiment'] + '.' + status['metric']['machine']
+    sliver_fqdn = status['metric']['experiment'] + '.' + status['metric'][
+        'machine']
     # 'status' is a list with two items. The first item ([0]) is a timestamp
     # marking the Prometheus evaluation time. The second, which is the one we
     # want, is the binary status value of the service.
@@ -202,7 +203,7 @@ def get_slice_status(url, opener):
 
     if statuses['status'] == 'error':
         logging.error('Prometheus returned error "%s" for URL %s.' %
-                     (statuses['error'], url))
+                      (statuses['error'], url))
         return None
 
     for status in statuses['data']['result']:

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -122,7 +122,14 @@ def get_slice_info(prometheus_base_url, tool_id, address_family):
                  'vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR '
               'lame_duck_node{} != bool 1)'
         ),
-        'ndt_ipv6': None,
+        'ndt_ipv6': (
+            'min by (machine) ( '
+              'probe_success{service="ndt_raw_ipv6"} OR '
+              'script_success{service="ndt_e2e"} OR '
+              '(vdlimit_used{experiment="ndt.iupui"} / '
+                 'vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR '
+              'lame_duck_node{} != bool 1)'
+        ),
         'ndt_ssl': (
             'min by (machine) ( '
               'probe_success{service="ndt_ssl"} OR '
@@ -131,7 +138,14 @@ def get_slice_info(prometheus_base_url, tool_id, address_family):
                  'vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR '
               'lame_duck_node{} != bool 1)'
         ),
-        'ndt_ssl_ipv6': None,
+        'ndt_ssl_ipv6': (
+            'min by (machine) ( '
+              'probe_success{service="ndt_ssl_ipv6"} OR '
+              'script_success{service="ndt_e2e"} OR '
+              '(vdlimit_used{experiment="ndt.iupui"} / '
+                 'vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR '
+              'lame_duck_node{} != bool 1)'
+        ),
         'neubot': 'probe_success{service="neubot"}',
         'neubot_ipv6': 'probe_success{service="neubot_ipv6"}',
         'mobiperf': (

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -24,9 +24,9 @@ class PrometheusSliceInfo(object):
     """Represents the information necessary to query Prometheus by slice.
 
     Attributes:
-        slice_url: URL for querying Prometheus.
-        tool_id: Name of a specific tool.
-        address_family: Formatted string for specifying ipv4 or ipv6.
+        slice_url: str, URL for querying Prometheus.
+        tool_id: str, name of a specific tool.
+        address_family: str, formatted string for specifying ipv4 or ipv6.
     """
 
     def __init__(self, slice_url, tool_id, address_family):
@@ -61,7 +61,8 @@ def authenticate_prometheus(prometheus):
     """Configures urllib to do HTTP Password authentication for Prometheus URLs.
 
     Args:
-        prometheus: object containing Prometheus auth information
+        prometheus: self.PrometheusSliceInfo, authentication information for
+        Prometheus.
 
     Returns:
         A urllib2 OpenerDirector object.
@@ -104,12 +105,12 @@ def get_slice_info(prometheus_base_url, tool_id, address_family):
     """Builds a a PrometheusSliceInfo object to query Prometheus for a slice.
 
     Args:
-        prometheus_base_url: Base URL to get Prometheus slice information.
+        prometheus_base_url: str, base URL to get Prometheus slice information.
         tool_id: str, the name of the sliver tool.
         address_family: str, empty for IPv4 or '_ipv6' for IPv6.
 
     Returns:
-         A PrometheusSliceInfo object for a slice.
+         A self.PrometheusSliceInfo object for a slice.
     """
     # This dict maps tool_ids to the corresponding Prometheus query that will
     # return the status for the tool.

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -147,7 +147,7 @@ def get_slice_info(prometheus_base_url, tool_id, address_family):
 
     query = urllib.quote_plus(queries[tool_id + address_family])
     slice_url = prometheus_base_url + query
-    return PrometheusSliceInfo(slice_url, tool_id, address_family))
+    return PrometheusSliceInfo(slice_url, tool_id, address_family)
 
 
 def get_slice_status(url, slice_id):

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -90,7 +90,7 @@ def parse_sliver_tool_status(status, slice_id):
 
     # Joins the experiment name with the machine name to form the FQDN fo the
     # experiment.
-    slice_fqdn = experiment + status['metric']['machine'])
+    slice_fqdn = experiment + status['metric']['machine']
     state = status['value'][1]
     # Prometheus doesn't return any sort of "tool_extra" like baseList.pl does
     # for Nagios, so instead we drop in the timestamp returned by Prometheus,

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -1,0 +1,210 @@
+import logging
+import re
+import urllib
+import urllib2
+
+from mlabns.db import model
+from mlabns.util import constants
+from mlabns.util import message
+
+
+class Error(Exception):
+    pass
+
+
+class PrometheusStatusUnparseableError(Error):
+    """Indicates that there was an error parsing Prometheus status information."""
+
+    def __init__(self, cause):
+        super(PrometheusStatusUnparseableError, self).__init__(cause)
+
+
+class PrometheusSliceInfo(object):
+    """Represents the information necessary to query Prometheus by slice.
+
+    Attributes:
+        slice_url: URL for querying Prometheus.
+        tool_id: Name of a specific tool.
+        address_family: Formatted string for specifying ipv4 or ipv6.
+    """
+
+    def __init__(self, slice_url, tool_id, address_family):
+        self._slice_url = slice_url
+        self._tool_id = tool_id
+        self._address_family = address_family
+
+    def __eq__(self, other):
+        return all([self.slice_url == other.slice_url,
+                    self.tool_id == other.tool_id,
+                    self.address_family == other.address_family])
+
+    def __ne__(self, other):
+        return any([self.slice_url != other.slice_url,
+                    self.tool_id != other.tool_id,
+                    self.address_family != other.address_family])
+
+    @property
+    def slice_url(self):
+        return self._slice_url
+
+    @property
+    def tool_id(self):
+        return self._tool_id
+
+    @property
+    def address_family(self):
+        return self._address_family
+
+
+def authenticate_prometheus(prometheus):
+    """Configures urllib to do HTTP Password authentication for Prometheus URLs.
+
+    Args:
+        prometheus: object containing Prometheus auth information
+    """
+    password_manager = urllib2.HTTPPasswordMgrWithDefaultRealm()
+    password_manager.add_password(None, prometheus.url, prometheus.username,
+                                  prometheus.password)
+
+    authhandler = urllib2.HTTPDigestAuthHandler(password_manager)
+    opener = urllib2.build_opener(authhandler)
+    urllib2.install_opener(opener)
+
+
+def parse_sliver_tool_status(status):
+    """Parses the status of a single sliver tool.
+
+    This status is returned from Prometheus, the M-Lab monitoring system.
+    Expected form is [fqdn][state][state type][extra notes]
+
+    Ex:
+        ndt.foo.measurement-lab.org/ndt 0 1 TCP OK - 0.242 second response time
+
+    Args:
+        status: One line corresponding to the status of a sliver tool.
+
+    Returns:
+        Tuple of the form (sliver fqdn, current state, extra information)
+
+    Raises:
+        PrometheusStatusUnparseableError: Error can be triggered by empty statuses
+            or statuses that can't be separated into exactly four fields.
+    """
+    sliver_fields = re.split(r'\s+', status.strip(), maxsplit=3)
+
+    if len(sliver_fields) != 4:
+        raise PrometheusStatusUnparseableError(
+            'Prometheus status missing or unparseable: %s' % status)
+
+    slice_fqdn = sliver_fields[0]
+    state = sliver_fields[1]
+    tool_extra = sliver_fields[3]
+    sliver_fqdn = slice_fqdn.split('/')[0]
+
+    return sliver_fqdn, state, tool_extra
+
+
+def get_slice_info(prometheus_base_url):
+    """Builds a list of PrometheusSliceInfo objects to query Prometheus for all slices.
+
+    Args:
+        prometheus_base_url: Base URL to get Prometheus slice information.
+
+    Returns:
+         List of PrometheusSliceInfo objects.
+    """
+    # This dict maps tool_ids to the corresponding Prometheus query that will
+    # return the status for the tool.
+    queries = {
+        'ndt': (
+            'min by (machine) ( '
+              'probe_success{service="ndt_raw"} OR '
+              'script_success{service="ndt_e2e"} OR '
+              '(vdlimit_used{experiment="ndt.iupui"} / '
+                 'vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR '
+              'lame_duck_node{} != bool 1)'
+        ),
+        'ndt_ipv6': '',
+        'ndt_ssl': (
+            'min by (machine) ( '
+              'probe_success{service="ndt_ssl"} OR '
+              'script_success{service="ndt_e2e"} OR '
+              '(vdlimit_used{experiment="ndt.iupui"} / '
+                 'vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR '
+              'lame_duck_node{} != bool 1)'
+        ),
+        'ndt_ssl_ipv6': '',
+        'neubot': 'probe_success{service="neubot"}',
+        'neubot_ipv6': 'probe_success{service="neubot_ipv6"}',
+        'mobiperf': (
+            'min by (machine) ( '
+              'probe_success{service="mobiperf", instance=~".*:6001"} OR '
+              'probe_success{service="mobiperf", instance=~".*:6002"} OR '
+              'probe_success{service="mobiperf", instance=~".*:6003"})'
+        ),
+        'mobiperf_ipv6': (
+            'min by (machine) ( '
+            'probe_success{service="mobiperf_ipv6", instance=~".*:6001"} OR '
+            'probe_success{service="mobiperf_ipv6", instance=~".*:6002"} OR '
+            'probe_success{service="mobiperf_ipv6", instance=~".*:6003"})'
+        )
+    }
+
+    slice_objects = []
+    for tool_id in model.get_all_tool_ids():
+        for address_family in ['', '_ipv6']:
+            query = urllib.quote_plus(queries[tool_id + address_family])
+            slice_url = prometheus_base_url + query
+            slice_objects.append(PrometheusSliceInfo(slice_url, tool_id,
+                                                     address_family))
+
+    return slice_objects
+
+
+def get_slice_status(url):
+    """Read slice status from Prometheus.
+
+    Args:
+        url: String representing the URL to Prometheus for a single slice.
+
+    Returns:
+        A dict mapping sliver fqdn to a dictionary representing the sliver's
+        status. For example:
+
+        {
+            'foo.mlab1.site1.measurement-lab.org': {
+                'status': 'online',
+                'tool_extra': 'example tool extra'
+                }
+        }
+
+        None if Prometheus status is blank or url is inaccessible.
+    """
+    status = {}
+    try:
+        lines = urllib2.urlopen(url).read().strip('\n').split('\n')
+    except urllib2.HTTPError:
+        # TODO(claudiu) Notify(email) when this happens.
+        logging.error('Cannot open %s.', url)
+        return None
+
+    lines = filter(lambda x: not x.isspace(), lines)
+    if not lines:
+        logging.info('Prometheus gave empty response for sliver status at the' \
+                     'following url: %s',url)
+        return None
+
+    for line in lines:
+        try:
+            sliver_fqdn, state, tool_extra = parse_sliver_tool_status(line)
+        except PrometheusStatusUnparseableError as e:
+            logging.error('Unable to parse Prometheus sliver status. %s', e)
+            continue
+
+        status[sliver_fqdn] = {'tool_extra': tool_extra}
+        if state == constants.NAGIOS_SERVICE_STATUS_OK:
+            status[sliver_fqdn]['status'] = message.STATUS_ONLINE
+        else:
+            status[sliver_fqdn]['status'] = message.STATUS_OFFLINE
+
+    return status

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -120,48 +120,56 @@ def get_slice_info(prometheus_base_url, tool_id, address_family):
               script_success{service="ndt_e2e"} OR
               (vdlimit_used{experiment="ndt.iupui"} /
                   vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR
-              lame_duck_experiment{} != bool 1)"""),
+              lame_duck_experiment{} != bool 1)
+              """),
         'ndt_ipv6': textwrap.dedent("""\
             min by (experiment, machine) (
               probe_success{service="ndt_raw_ipv6"} OR
               script_success{service="ndt_e2e"} OR
               (vdlimit_used{experiment="ndt.iupui"} /
                   vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR
-              lame_duck_experiment{} != bool 1)"""),
+              lame_duck_experiment{} != bool 1)
+              """),
         'ndt_ssl': textwrap.dedent("""\
             min by (experiment, machine) (
               probe_success{service="ndt_ssl"} OR
               script_success{service="ndt_e2e"} OR
               (vdlimit_used{experiment="ndt.iupui"} /
                   vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR
-              lame_duck_experiment{} != bool 1)"""),
+              lame_duck_experiment{} != bool 1)
+              """),
         'ndt_ssl_ipv6': textwrap.dedent("""\
             min by (experiment, machine) (
               probe_success{service="ndt_ssl_ipv6"} OR
               script_success{service="ndt_e2e"} OR
               (vdlimit_used{experiment="ndt.iupui"} /
                   vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR
-              lame_duck_experiment{} != bool 1)"""),
+              lame_duck_experiment{} != bool 1)
+              """),
         'neubot': textwrap.dedent("""\
             min by (experiment, machine) (
               probe_success{service="neubot"} OR
-              lame_duck_experiment{} != bool 1)"""),
+              lame_duck_experiment{} != bool 1)
+              """),
         'neubot_ipv6': textwrap.dedent("""\
             min by (experiment, machine) (
               probe_success{service="neubot_ipv6"} OR
-              lame_duck_experiment{} != bool 1)"""),
+              lame_duck_experiment{} != bool 1)
+              """),
         'mobiperf': textwrap.dedent("""\
             min by (experiment, machine) (
               probe_success{service="mobiperf", instance=~".*:6001"} OR
               probe_success{service="mobiperf", instance=~".*:6002"} OR
               probe_success{service="mobiperf", instance=~".*:6003"} OR
-              lame_duck_experiment{} != bool 1)"""),
+              lame_duck_experiment{} != bool 1)
+              """),
         'mobiperf_ipv6': textwrap.dedent("""\
             min by (experiment, machine) (
               probe_success{service="mobiperf_ipv6", instance=~".*:6001"} OR
               probe_success{service="mobiperf_ipv6", instance=~".*:6002"} OR
               probe_success{service="mobiperf_ipv6", instance=~".*:6003"} OR
-              lame_duck_experiment{} != bool 1)"""),
+              lame_duck_experiment{} != bool 1)
+              """),
     }
 
     query = urllib.quote_plus(queries[tool_id + address_family])

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -115,52 +115,43 @@ def get_slice_info(prometheus_base_url, tool_id, address_family):
     # This dict maps tool_ids to the corresponding Prometheus query that will
     # return the status for the tool.
     queries = {
-        'ndt': (
-            'min by (machine) ( '
-              'probe_success{service="ndt_raw"} OR '
-              'script_success{service="ndt_e2e"} OR '
-              '(vdlimit_used{experiment="ndt.iupui"} / '
-                 'vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR '
-              'lame_duck_node{} != bool 1)'
-        ),
-        'ndt_ipv6': (
-            'min by (machine) ( '
-              'probe_success{service="ndt_raw_ipv6"} OR '
-              'script_success{service="ndt_e2e"} OR '
-              '(vdlimit_used{experiment="ndt.iupui"} / '
-                 'vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR '
-              'lame_duck_node{} != bool 1)'
-        ),
-        'ndt_ssl': (
-            'min by (machine) ( '
-              'probe_success{service="ndt_ssl"} OR '
-              'script_success{service="ndt_e2e"} OR '
-              '(vdlimit_used{experiment="ndt.iupui"} / '
-                 'vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR '
-              'lame_duck_node{} != bool 1)'
-        ),
-        'ndt_ssl_ipv6': (
-            'min by (machine) ( '
-              'probe_success{service="ndt_ssl_ipv6"} OR '
-              'script_success{service="ndt_e2e"} OR '
-              '(vdlimit_used{experiment="ndt.iupui"} / '
-                 'vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR '
-              'lame_duck_node{} != bool 1)'
-        ),
+        'ndt': ('min by (machine) ( '
+                'probe_success{service="ndt_raw"} OR '
+                'script_success{service="ndt_e2e"} OR '
+                '(vdlimit_used{experiment="ndt.iupui"} / '
+                'vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR '
+                'lame_duck_node{} != bool 1)'),
+        'ndt_ipv6': ('min by (machine) ( '
+                     'probe_success{service="ndt_raw_ipv6"} OR '
+                     'script_success{service="ndt_e2e"} OR '
+                     '(vdlimit_used{experiment="ndt.iupui"} / '
+                     'vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR '
+                     'lame_duck_node{} != bool 1)'),
+        'ndt_ssl': ('min by (machine) ( '
+                    'probe_success{service="ndt_ssl"} OR '
+                    'script_success{service="ndt_e2e"} OR '
+                    '(vdlimit_used{experiment="ndt.iupui"} / '
+                    'vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR '
+                    'lame_duck_node{} != bool 1)'),
+        'ndt_ssl_ipv6':
+        ('min by (machine) ( '
+         'probe_success{service="ndt_ssl_ipv6"} OR '
+         'script_success{service="ndt_e2e"} OR '
+         '(vdlimit_used{experiment="ndt.iupui"} / '
+         'vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR '
+         'lame_duck_node{} != bool 1)'),
         'neubot': 'probe_success{service="neubot"}',
         'neubot_ipv6': 'probe_success{service="neubot_ipv6"}',
-        'mobiperf': (
-            'min by (machine) ( '
-              'probe_success{service="mobiperf", instance=~".*:6001"} OR '
-              'probe_success{service="mobiperf", instance=~".*:6002"} OR '
-              'probe_success{service="mobiperf", instance=~".*:6003"})'
-        ),
-        'mobiperf_ipv6': (
-            'min by (machine) ( '
-            'probe_success{service="mobiperf_ipv6", instance=~".*:6001"} OR '
-            'probe_success{service="mobiperf_ipv6", instance=~".*:6002"} OR '
-            'probe_success{service="mobiperf_ipv6", instance=~".*:6003"})'
-        )
+        'mobiperf':
+        ('min by (machine) ( '
+         'probe_success{service="mobiperf", instance=~".*:6001"} OR '
+         'probe_success{service="mobiperf", instance=~".*:6002"} OR '
+         'probe_success{service="mobiperf", instance=~".*:6003"})'),
+        'mobiperf_ipv6':
+        ('min by (machine) ( '
+         'probe_success{service="mobiperf_ipv6", instance=~".*:6001"} OR '
+         'probe_success{service="mobiperf_ipv6", instance=~".*:6002"} OR '
+         'probe_success{service="mobiperf_ipv6", instance=~".*:6003"})')
     }
 
     query = urllib.quote_plus(queries[tool_id + address_family])
@@ -199,14 +190,14 @@ def get_slice_status(url, opener, slice_id):
     statuses = json.loads(raw_data)
 
     if statuses['status'] == 'error':
-        logging.info('Prometheus returned error "%s" for URL %s.'
-                     % (statuses['error'], url))
+        logging.info('Prometheus returned error "%s" for URL %s.' %
+                     (statuses['error'], url))
         return None
 
     for status in statuses['data']['result']:
         try:
             sliver_fqdn, state, tool_extra = parse_sliver_tool_status(status,
-                    slice_id)
+                                                                      slice_id)
         except PrometheusStatusUnparseableError as e:
             logging.error('Unable to parse Prometheus sliver status. %s', e)
             continue

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -174,7 +174,7 @@ def get_slice_status(url, opener, slice_id):
 
         None if Prometheus status is blank or url is inaccessible.
     """
-    status = {}
+    results = {}
     try:
         raw_data = opener.open(url).read()
     except urllib2.HTTPError:
@@ -196,10 +196,10 @@ def get_slice_status(url, opener, slice_id):
             logging.error('Unable to parse Prometheus sliver status. %s', e)
             continue
 
-        status[sliver_fqdn] = {'tool_extra': tool_extra}
+        results[sliver_fqdn] = {'tool_extra': tool_extra}
         if state == constants.PROMETHEUS_SERVICE_STATUS_OK:
-            status[sliver_fqdn]['status'] = message.STATUS_ONLINE
+            results[sliver_fqdn]['status'] = message.STATUS_ONLINE
         else:
-            status[sliver_fqdn]['status'] = message.STATUS_OFFLINE
+            results[sliver_fqdn]['status'] = message.STATUS_OFFLINE
 
-    return status
+    return results


### PR DESCRIPTION
We desperately want to stop having production dependencies on Nagios. We are already using Prometheus for a lot of things. One big piece of production code still relying on Nagios is mlab-ns. The PR implements the ability for mlab-ns to update experiment status using Prometheus or Nagios.

A non-goal of this change was to make mlab-ns code better. Instead, the goal was to touch as little of the code as possible, and to change as little of the current code flow as possible. The code may not be great, and flow may not be efficient or ideal, but we _mostly_ trust it to do the right thing. I wanted to avoid making any changes that might introduce subtle bugs that went undetected. We plan on replacing the current mlab-ns codebase with a rewrite at some point in the future anyway.

The implementation here introduces some amount of code redundancy between Nagios and Prometheus. Again, this was intentional. I wanted to touch the Nagios parts of the code as little as possible. So, for example, instead of having a single function that handles either Nagios or Prometheus, I duplicated the function, leaving the Nagios one untouched (to the extent possible), creating a new one for Prometheus.

This code is currently running in as the 'prometheus' service in mlab-nstesting:

https://prometheus-dot-mlab-nstesting.appspot.com/admin/map/ipv4/all

You can verify that the status data came from Prometheus by look at the `tool_extra` column in the SliverTool datastore kind, which should indicate that it was touched by the Prometheus parts of the code.

There are a few sites that are still not updating properly from Prom for some reason, and I still need to investigate why: acc02, lca01, los01, mpm01, tnr01.

Of particular interest in the PR should be the Prometheus status queries in util/prometheus_status.py. I believe them to be correct and accurate, but this should be verified by someone else.

**NOTE**: I have temporarily removed the `check_status` cron job, which runs against the default service, and uses Nagios. I didn't want it overwriting the Prometheus updates to the datastore every single minute.  One can manually trigger an update with this code by fetching this URL:

https://prometheus-dot-mlab-nstesting.appspot.com/cron/check_status

You can toggle whether mlab-ns fetches it's status from Prometheus or Nagios by modifying the `status_source` field in the Tool table:

https://console.cloud.google.com/datastore/entities/query?project=mlab-nstesting&ns=&kind=Tool

Currently, I have set all tools that we care about to get their status from Prometheus to put this through its paces, but if/when we deploy this we'll want to start with a single service, probably neubot, leaving the rest with Nagios during the trial.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/128)
<!-- Reviewable:end -->
