### PR TITLE
Preserves every sliver tool in memcache, whether it exists in monitoring data or not.

### DIFF
--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -443,6 +443,10 @@ class StatusUpdateHandler(webapp.RequestHandler):
                     slice_status[sliver_tool.fqdn][
                         'tool_extra'] = sliver_tool.tool_extra + '(Family "_ipv6" for sliver not known by monitoring).'
                 else:
+                    # If monitoring data doesn't exist for this tool, append
+                    # the sliver_tool unmodified to the list that gets written
+                    # back to memcache.
+                    updated_sliver_tools.append(sliver_tool)
                     continue
 
             if family == '':


### PR DESCRIPTION
Currently, if a slivertool exists in mlab-ns's memcache, but does not exist in the results returned by Prometheus, it will be implicitly removed from memcache. If there is some sort of major failure in Prometheus, or a bug in our PromQL queries, that causes some or all slivertools to not be present in the monitoring data returned by a query, memcache may only know about some slivertools. If the failure is large, memcache may get close to empty and global traffic will possibly be directed at just the few remaining slivertools.

This PR ensures that all slivertools in memcache at the time the `check_status` cron job is run will remain in memcache, even if it means that the true status of the slivertool is unknown.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/146)
<!-- Reviewable:end -->
