### PR TITLE
Return a record for every service, even if a particular metric is missing.

### DIFF
--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -41,124 +41,120 @@ QUERIES = {
     'ndt': textwrap.dedent("""\
         min by (experiment, machine) (
           (
-            (
-              (probe_success{service="ndt_raw"}) +
-              ON (experiment, machine) (script_success{service="ndt_e2e"}) +
-              ON (experiment, machine) ((vdlimit_used{experiment="ndt.iupui"} /
-                vdlimit_total{experiment="ndt.iupui"}) < bool 0.95) +
-              ON (experiment, machine)
-                (lame_duck_experiment{experiment="ndt.iupui"} != bool 1)
-            ) == bool 4
-          ) OR
-          ON(experiment, machine) probe_success{service="ndt_raw"}
+            (probe_success{service="ndt_raw"}) +
+            ON (experiment, machine) (script_success{service="ndt_e2e"}) +
+            ON (experiment, machine) ((vdlimit_used{experiment="ndt.iupui"} /
+              vdlimit_total{experiment="ndt.iupui"}) < bool 0.95) +
+            ON (experiment, machine)
+              (lame_duck_experiment{experiment="ndt.iupui"} != bool 1)
+          ) == bool 4
+          OR ON(experiment, machine) up{service="ndt_raw"} == 0
+          OR ON(experiment, machine) up{service="ndt_e2e"} == 0
+          OR ON(experiment, machine) up{service="ndt_raw"}
             UNLESS ON(machine) up{service="nodeexporter"} == 1
         )
         """),
     'ndt_ipv6': textwrap.dedent("""\
         min by (experiment, machine) (
           (
-            (
-              (probe_success{service="ndt_raw_ipv6"}) +
-              ON (experiment, machine) (script_success{service="ndt_e2e"}) +
-              ON (experiment, machine) ((vdlimit_used{experiment="ndt.iupui"} /
-                vdlimit_total{experiment="ndt.iupui"}) < bool 0.95) +
-              ON (experiment, machine)
-                (lame_duck_experiment{experiment="ndt.iupui"} != bool 1)
-            ) == bool 4
-          ) OR
-          ON(experiment, machine) probe_success{service="ndt_raw_ipv6"}
+            (probe_success{service="ndt_raw_ipv6"}) +
+            ON (experiment, machine) (script_success{service="ndt_e2e"}) +
+            ON (experiment, machine) ((vdlimit_used{experiment="ndt.iupui"} /
+              vdlimit_total{experiment="ndt.iupui"}) < bool 0.95) +
+            ON (experiment, machine)
+              (lame_duck_experiment{experiment="ndt.iupui"} != bool 1)
+          ) == bool 4
+          OR ON(experiment, machine) up{service="ndt_raw_ipv6"} == 0
+          OR ON(experiment, machine) up{service="ndt_e2e"} == 0
+          OR ON(experiment, machine) up{service="ndt_raw_ipv6"}
             UNLESS ON(machine) up{service="nodeexporter"} == 1
         )
         """),
     'ndt_ssl': textwrap.dedent("""\
         min by (experiment, machine) (
           (
-            (
-              (probe_success{service="ndt_ssl"}) +
-              ON (experiment, machine) (script_success{service="ndt_e2e"}) +
-              ON (experiment, machine)((vdlimit_used{experiment="ndt.iupui"} /
-                vdlimit_total{experiment="ndt.iupui"}) < bool 0.95) +
-              ON (experiment, machine)
-                (lame_duck_experiment{experiment="ndt.iupui"} != bool 1)
-            ) == bool 4
-          ) OR
-          ON(experiment, machine) probe_success{service="ndt_ssl"}
+            (probe_success{service="ndt_ssl"}) +
+            ON (experiment, machine) (script_success{service="ndt_e2e"}) +
+            ON (experiment, machine) ((vdlimit_used{experiment="ndt.iupui"} /
+              vdlimit_total{experiment="ndt.iupui"}) < bool 0.95) +
+            ON (experiment, machine)
+              (lame_duck_experiment{experiment="ndt.iupui"} != bool 1)
+          ) == bool 4
+          OR ON(experiment, machine) up{service="ndt_ssl"} == 0
+          OR ON(experiment, machine) up{service="ndt_e2e"} == 0
+          OR ON(experiment, machine) up{service="ndt_ssl"}
             UNLESS ON(machine) up{service="nodeexporter"} == 1
         )
         """),
     'ndt_ssl_ipv6': textwrap.dedent("""\
         min by (experiment, machine) (
           (
-            (
-              (probe_success{service="ndt_ssl_ipv6"}) +
-              ON (experiment, machine) (script_success{service="ndt_e2e"}) +
-              ON (experiment, machine) ((vdlimit_used{experiment="ndt.iupui"} /
-                  vdlimit_total{experiment="ndt.iupui"}) < bool 0.95) +
-              ON (experiment, machine)
-                (lame_duck_experiment{experiment="ndt.iupui"} != bool 1)
-            ) == bool 4
-          ) OR
-          ON(experiment, machine) probe_success{service="ndt_ssl_ipv6"}
+            (probe_success{service="ndt_ssl_ipv6"}) +
+            ON (experiment, machine) (script_success{service="ndt_e2e"}) +
+            ON (experiment, machine) ((vdlimit_used{experiment="ndt.iupui"} /
+              vdlimit_total{experiment="ndt.iupui"}) < bool 0.95) +
+            ON (experiment, machine)
+              (lame_duck_experiment{experiment="ndt.iupui"} != bool 1)
+          ) == bool 4
+          OR ON(experiment, machine) up{service="ndt_ssl_ipv6"} == 0
+          OR ON(experiment, machine) up{service="ndt_e2e"} == 0
+          OR ON(experiment, machine) up{service="ndt_ssl_ipv6"}
             UNLESS ON(machine) up{service="nodeexporter"} == 1
         )
         """),
     'neubot': textwrap.dedent("""\
         min by (experiment, machine) (
           (
-            (
-              (probe_success{service="neubot"}) +
-              ON (experiment, machine)
-                (lame_duck_experiment{experiment="neubot.mlab"} != bool 1)
-            ) == bool 2
-          ) OR
-          ON(experiment, machine) probe_success{service="neubot"}
+            (probe_success{service="neubot"}) +
+            ON (experiment, machine)
+              (lame_duck_experiment{experiment="neubot.mlab"} != bool 1)
+          ) == bool 2
+          OR ON(experiment, machine) up{service="neubot"} == 0
+          OR ON(experiment, machine) up{service="neubot"}
             UNLESS ON(machine) up{service="nodeexporter"} == 1
         )
         """),
     'neubot_ipv6': textwrap.dedent("""\
         min by (experiment, machine) (
           (
-            (
-              (probe_success{service="neubot_ipv6"}) +
-              ON (experiment, machine)
-                (lame_duck_experiment{experiment="neubot.mlab"} != bool 1)
-            ) == bool 2
-          ) OR
-          ON(experiment, machine) probe_success{service="neubot_ipv6"}
+            (probe_success{service="neubot_ipv6"}) +
+            ON (experiment, machine)
+              (lame_duck_experiment{experiment="neubot.mlab"} != bool 1)
+          ) == bool 2
+          OR ON(experiment, machine) up{service="neubot_ipv6"} == 0
+          OR ON(experiment, machine) up{service="neubot_ipv6"}
             UNLESS ON(machine) up{service="nodeexporter"} == 1
         )
         """),
     'mobiperf': textwrap.dedent("""\
         min by (experiment, machine) (
           (
-            (
-              (probe_success{service="mobiperf", instance=~".*:6001"}) +
-              ON (experiment, machine)
-                (probe_success{service="mobiperf", instance=~".*:6002"}) +
-              ON (experiment, machine)
-                (probe_success{service="mobiperf", instance=~".*:6003"}) +
-              ON (experiment, machine)
-                (lame_duck_experiment{experiment="1.michigan"} != bool 1)
-            ) == bool 4
-          ) OR
-          ON(experiment, machine) probe_success{service="mobiperf"}
+            (probe_success{service="mobiperf", instance=~".*:6001"}) +
+            ON (experiment, machine)
+              (probe_success{service="mobiperf", instance=~".*:6002"}) +
+            ON (experiment, machine)
+              (probe_success{service="mobiperf", instance=~".*:6003"}) +
+            ON (experiment, machine)
+              (lame_duck_experiment{experiment="1.michigan"} != bool 1)
+          ) == bool 4
+          OR ON(experiment, machine) up{service="mobiperf"} == 0
+          OR ON(experiment, machine) up{service="mobiperf"}
             UNLESS ON(machine) up{service="nodeexporter"} == 1
         )
         """),
     'mobiperf_ipv6': textwrap.dedent("""\
         min by (experiment, machine) (
           (
-            (
-              (probe_success{service="mobiperf_ipv6", instance=~".*:6001"}) +
-              ON (experiment, machine)
-                (probe_success{service="mobiperf_ipv6", instance=~".*:6002"}) +
-              ON (experiment, machine)
-                (probe_success{service="mobiperf_ipv6", instance=~".*:6003"}) +
-              ON (experiment, machine)
-                (lame_duck_experiment{experiment="1.michigan"} != bool 1)
-            ) == bool 4
-          ) OR
-          ON(experiment, machine) probe_success{service="mobiperf_ipv6"}
+            (probe_success{service="mobiperf_ipv6", instance=~".*:6001"}) +
+            ON (experiment, machine)
+              (probe_success{service="mobiperf_ipv6", instance=~".*:6002"}) +
+            ON (experiment, machine)
+              (probe_success{service="mobiperf_ipv6", instance=~".*:6003"}) +
+            ON (experiment, machine)
+              (lame_duck_experiment{experiment="1.michigan"} != bool 1)
+          ) == bool 4
+          OR ON(experiment, machine) up{service="mobiperf_ipv6"} == 0
+          OR ON(experiment, machine) up{service="mobiperf_ipv6"}
             UNLESS ON(machine) up{service="nodeexporter"} == 1
         )
         """),


### PR DESCRIPTION
In a recent incident that affected global traffic, we came to understand that we cannot count on any given metric actually existing for any particular instantaneous query. This PR modifies the Prometheus queries mlab-ns issues such that even if a metric is missing, a result (of 0) will still be returned for machine/service.

**IMPORTANT CONSIDERATION**: In PR #146 we added a feature whereby if status for a particular "tool" on a particular machine is missing from the data returned by Prometheus, we don't touch the existing status of the slivertool in mlab-ns. That is, in the absence of data, we do nothing to change the status quo. This PR is going to affect that such that missing metrics will mark a slivertool as down in mlab-ns. This may be what we want. That is, we may want to say: If we don't know the status of a slivertool, then flag it as down until we do know the true status. However, the downside to this is that we could end up in another situation where, say, the blackbox_exporter goes down for 5 or 10 minutes removing a bunch of metrics. With this PR, mlab-ns will flag everything for which there is some missing metric down. A service interruption in the Prometheus flow could take down most of the fleet in this way.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/149)
<!-- Reviewable:end -->
