### PR TITLE
Use the datastore as the source of truth, not memcache.

### DIFF
--- a/server/mlabns/db/sliver_tool_fetcher.py
+++ b/server/mlabns/db/sliver_tool_fetcher.py
@@ -255,5 +255,6 @@ class SliverToolFetcherDatastore(object):
         if not tool_properties.all_slivers:
             results = _filter_choose_one_host_per_site(results)
 
-        logging.info('%d sliver tools found in Datastore.', len(results))
+        logging.info('{}: {} sliver tools found in datastore.'.format(
+            tool_properties.tool_id, len(results)))
         return results

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -429,7 +429,7 @@ class StatusUpdateHandler(webapp.RequestHandler):
                         'status'] = message.STATUS_OFFLINE
                     # Don't wipe out the IPv4 'tool_extra', just append to it.
                     slice_status[sliver_tool.fqdn][
-                        'tool_extra'] = sliver_tool.tool_extra + '(Family "_ipv6" for sliver not known by monitoring).'
+                        'tool_extra'] = constants.PROMETHEUS_TOOL_EXTRA + '(Family "_ipv6" for sliver not known by monitoring).'
                 else:
                     # If monitoring data doesn't exist for this tool, append
                     # the sliver_tool unmodified to the list, since in the

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -422,7 +422,7 @@ class StatusUpdateHandler(webapp.RequestHandler):
                 to an IP address.
             family: Address family to update.
         """
-        sliver_tools = sliver_tool_fetcher.SliverToolFetcher().fetch(
+        sliver_tools = sliver_tool_fetcher.SliverToolFetcherDatastore.fetch(
             sliver_tool_fetcher.ToolProperties(tool_id=tool_id,
                                                all_slivers=True))
         updated_sliver_tools = []
@@ -444,8 +444,9 @@ class StatusUpdateHandler(webapp.RequestHandler):
                         'tool_extra'] = sliver_tool.tool_extra + '(Family "_ipv6" for sliver not known by monitoring).'
                 else:
                     # If monitoring data doesn't exist for this tool, append
-                    # the sliver_tool unmodified to the list that gets written
-                    # back to memcache.
+                    # the sliver_tool unmodified to the list, since in the
+                    # absence of status data we are better off having stale
+                    # data than marking the sliver as down.
                     updated_sliver_tools.append(sliver_tool)
                     continue
 

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -99,7 +99,7 @@ class SiteRegistrationHandler(webapp.RequestHandler):
             site_ids.add(site[self.SITE_FIELD])
 
         mlab_site_ids = set()
-        mlab_sites = model.Site.all()
+        mlab_sites = list(model.Site.all().fetch(limit=None))
         for site in mlab_sites:
             mlab_site_ids.add(site.site_id)
 

--- a/server/mlabns/tests/test_update.py
+++ b/server/mlabns/tests/test_update.py
@@ -4,6 +4,7 @@ import unittest2
 import urllib2
 
 from google.appengine.api import app_identity
+from google.appengine.ext import db
 from mlabns.db import model
 from mlabns.handlers import update
 from mlabns.util import util
@@ -30,6 +31,10 @@ class SiteRegistrationHandlerTest(unittest2.TestCase):
         self.addCleanup(site_model_patch.stop)
         site_model_patch.start()
 
+        query_db_patch = mock.patch.object(db, 'Query', autospec=True)
+        self.addCleanup(query_db_patch.stop)
+        query_db_patch.start()
+
         tool_model_patch = mock.patch.object(model, 'Tool', autospec=True)
         self.addCleanup(tool_model_patch.stop)
         tool_model_patch.start()
@@ -53,7 +58,7 @@ class SiteRegistrationHandlerTest(unittest2.TestCase):
 }
 ]""")
         app_identity.get_application_id.return_value = 'mlab-nstesting'
-        model.Site.all.return_value = [mock.Mock(site_id='xyz01')]
+        db.Query.fetch.return_value = [mock.Mock(site_id='xyz01')]
         handler = update.SiteRegistrationHandler()
         handler.get()
 
@@ -77,7 +82,7 @@ class SiteRegistrationHandlerTest(unittest2.TestCase):
 }
 ]""")
         app_identity.get_application_id.return_value = 'mlab-nstesting'
-        model.Site.all.return_value = [mock.Mock(site_id='xyz01')]
+        db.Query.fetch.return_value = [mock.Mock(site_id='xyz01')]
         handler = update.SiteRegistrationHandler()
         handler.get()
 

--- a/server/mlabns/util/constants.py
+++ b/server/mlabns/util/constants.py
@@ -27,7 +27,11 @@ GEOLOCATION_MAXMIND_BUCKET_PATH = 'maxmind/current'
 GEOLOCATION_MAXMIND_CITY_FILE = 'GeoLite2-City.mmdb'
 
 # Maximum number of entities fetched from datastore in a single query.
-MAX_FETCHED_RESULTS = 500
+#
+# https://cloud.google.com/appengine/docs/standard/python/datastore/gqlqueryclass:
+# "Maximum number of results to return. If set to None, all available results
+# will be retrieved."
+MAX_FETCHED_RESULTS = None
 
 # Memcache namespace for map: tool_id -> list of sliver_tools.
 MEMCACHE_NAMESPACE_TOOLS = 'memcache_tools'


### PR DESCRIPTION
The primary purpose of this PR (and the smallest amount of changes) is to change the `check_status` cron job to use the datastore as the source of truth instead of what happens to be in memcache. Currently, `check_status` reads what is in memcache for a given tool and then iterates over it to determine if there are any status changes. The problem with this is that memcache (as we use it) is a "best-effort" service, and the contents of memcache might disappear at any moment for any reason.

From: https://cloud.google.com/appengine/articles/best-practices-for-app-engine-memcache

> Data stored in Memcache can be evicted at any time, so applications should be structured in a way that does not depend on the presence of entries. [...] Shared Memcache is a no-cost, best-effort service, and data stored with this service can be evicted at any time.

Furthermore, if data gets evicted from memcache, or a bug in our code removes it accidentally, as was the case in a recent incident, `check_status` does not try to verify that what is in memcache represents the full platform inventory. Thus if memcache is somehow truncated, mlab-ns will only updates status for and advertise to the world this truncated set of slivertools.

This PR causes `check_status` to read all known slivertools from the **datastore** instead of memcache. When it is done updating status on these slivertools, it first writes the updated data back to the **datastore**. When everything is done, it dumps this updated status to memcache.

This PR also stops the `IPUpdateHandler()` from writing anything to memcache, which should 
 resolve issue #97, since now only a single job is ever writing anything to memcache. 

With these changes, if memcache get corrupted or truncated for any reason, it will be updated with the full set of slivertools in the datastore the next time `check_status` runs, which will be less than 1m.

The second goal of this PR, and the one which actually makes up the majority of the code changes, is to improve the performance of the `IPUpdateHandler()` code. Currently this code takes between 3-5 minutes to run. The reason for this long run time is that it currently make 15,000 to 20,000 individual datastore queries. This PR fixes that by fetching all the data from the datastore that it needs up front, in 3 big queries. With these changes the runtime for `IPUpdateHandler()` is only about 25s.

One other small fix in the PR is that currently [there is a constant in util/constants.py](https://github.com/m-lab/mlab-ns/blob/master/server/mlabns/util/constants.py#L30) that configures mlab-ns to never fetch more than 500 records from the datastore. We now have more than 500 nodes, and this has been excluding some slivertools from getting updated.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/150)
<!-- Reviewable:end -->
