### PR TITLE
Don't append to tool_extra because it will grow out of control.

### DIFF
--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -439,9 +439,9 @@ class StatusUpdateHandler(webapp.RequestHandler):
                     slice_status[sliver_tool.fqdn] = {}
                     slice_status[sliver_tool.fqdn][
                         'status'] = message.STATUS_OFFLINE
-                    # Don't wipe out the IPv4 'tool_extra', just append to it.
+                    # Update tool_extra to signal that _ipv6 is not known.
                     slice_status[sliver_tool.fqdn][
-                        'tool_extra'] = sliver_tool.tool_extra + '(Family "_ipv6" for sliver not known by monitoring).'
+                        'tool_extra'] = constants.PROMETHEUS_TOOL_EXTRA + ' (Family "_ipv6" for sliver not known by monitoring).'
                 else:
                     # If monitoring data doesn't exist for this tool, append
                     # the sliver_tool unmodified to the list that gets written


### PR DESCRIPTION
 Instead just update it. Fixes #151.

In the not-distant future our use of `tool_extra` will likely go away as it is vestigial, from the Nagios days. There is no such concept of `tool_extra` for Prometheus.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/152)
<!-- Reviewable:end -->
