### PR TITLE
Reverts the Prometheus queries to the way they were originally created.

### DIFF
--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -9,6 +9,19 @@ from mlabns.util import message
 
 # This global dict maps tool_ids to the corresponding Prometheus query that
 # will return the status for that tool.
+#
+# IMPORTANT NOTE: When querying multiple metrics from the same exporter (e.g.,
+# node_exporter), be sure that the label set for each metric is unique. The `OR`
+# operator in Prometheus will exclude all metrics but one in the case where they
+# have the same label set. For example, in the queries below the vdlimit_* and
+# lame_duck_experiment metrics both come from node_exporter. By default, these
+# metrics on the same machine will have identical label sets. In this particular
+# case, to get around this, we have added unique labels to each metric via the
+# scripts that generate the node_exporter metrics files on each node. So, if,
+# for example, another blackbox_exporter metric is added (i.e., another
+# probe_success), something will need to be done to make sure that the label
+# sets are unique for each metric, even if it means using label_replace() in
+# these queries.
 QUERIES = {
     'ndt': textwrap.dedent("""\
         min by (experiment, machine) (

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -9,157 +9,69 @@ from mlabns.util import message
 
 # This global dict maps tool_ids to the corresponding Prometheus query that
 # will return the status for that tool.
-#
-# NOTE: These queries are rather unintuitive and bear some explanation. A
-# previous iteration of the queries was using the `OR` operator to join
-# vectors. However, the `OR` operator has a behavior which makes it unsuitable
-# for use with these queries. The `OR` operator will exclude timeseries, except
-# the first, with matching labelsets. Because, in the case of the NDT queries,
-# the last two vectors (vdlimit_* and lame_duck_experiment) are both
-# node_exporter metrics, they have matching label sets. This meant that the
-# lame_duck_experiment vector was getting excluded, making it impossible to
-# remove a node from mlab-ns rotation via the lame-duck mechanism.
-#
-# The current format adds the value of the vectors. If the count is equal to
-# the number of vectors, then they all have a value of 1, meaning everything is
-# up, else something is down and the node should be taken out of mlab-ns
-# rotation. The `== bool 4` ensures that the resulting value will be 0 if the
-# count is less than 4.
-#
-# The final use of `OR` in the queries takes into account where, for some
-# reason, node_exporter may not be running on a node, hence the nodeexporter
-# metrics will be missing, causing metrics for those nodes to be missing from
-# the overall result set. To add these nodes back to the result set we query a
-# metric we expect should represent all possible nodes for the experiment, then
-# subtract all nodes where up{service="nodeexporter"}==1, leaving us nodes
-# where node_exporter is 0 (down).
-#
-# The use of `min by` in the queries ensures any timeseries added by the final
-# `OR` have the exact same label set as the others. In this way, it is a
-# built-in sanity check that every timeseries has a consistent set of labels.
 QUERIES = {
     'ndt': textwrap.dedent("""\
         min by (experiment, machine) (
-          (
-            (
-              (probe_success{service="ndt_raw"}) +
-              ON (experiment, machine) (script_success{service="ndt_e2e"}) +
-              ON (experiment, machine) ((vdlimit_used{experiment="ndt.iupui"} /
-                vdlimit_total{experiment="ndt.iupui"}) < bool 0.95) +
-              ON (experiment, machine)
-                (lame_duck_experiment{experiment="ndt.iupui"} != bool 1)
-            ) == bool 4
-          ) OR
-          ON(experiment, machine) probe_success{service="ndt_raw"}
-            UNLESS ON(machine) up{service="nodeexporter"} == 1
+            probe_success{service="ndt_raw"} OR
+            script_success{service="ndt_e2e"} OR
+            (vdlimit_used{experiment="ndt.iupui"} /
+              vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR
+            lame_duck_experiment{experiment="ndt.iupui"} != bool 1
         )
         """),
     'ndt_ipv6': textwrap.dedent("""\
         min by (experiment, machine) (
-          (
-            (
-              (probe_success{service="ndt_raw_ipv6"}) +
-              ON (experiment, machine) (script_success{service="ndt_e2e"}) +
-              ON (experiment, machine) ((vdlimit_used{experiment="ndt.iupui"} /
-                vdlimit_total{experiment="ndt.iupui"}) < bool 0.95) +
-              ON (experiment, machine)
-                (lame_duck_experiment{experiment="ndt.iupui"} != bool 1)
-            ) == bool 4
-          ) OR
-          ON(experiment, machine) probe_success{service="ndt_raw_ipv6"}
-            UNLESS ON(machine) up{service="nodeexporter"} == 1
+            probe_success{service="ndt_raw_ipv6"} OR
+            script_success{service="ndt_e2e"} OR
+            (vdlimit_used{experiment="ndt.iupui"} /
+              vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR
+            lame_duck_experiment{experiment="ndt.iupui"} != bool 1
         )
         """),
     'ndt_ssl': textwrap.dedent("""\
         min by (experiment, machine) (
-          (
-            (
-              (probe_success{service="ndt_ssl"}) +
-              ON (experiment, machine) (script_success{service="ndt_e2e"}) +
-              ON (experiment, machine)((vdlimit_used{experiment="ndt.iupui"} /
-                vdlimit_total{experiment="ndt.iupui"}) < bool 0.95) +
-              ON (experiment, machine)
-                (lame_duck_experiment{experiment="ndt.iupui"} != bool 1)
-            ) == bool 4
-          ) OR
-          ON(experiment, machine) probe_success{service="ndt_ssl"}
-            UNLESS ON(machine) up{service="nodeexporter"} == 1
+            probe_success{service="ndt_ssl"} OR
+            script_success{service="ndt_e2e"} OR
+            (vdlimit_used{experiment="ndt.iupui"} /
+              vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR
+            lame_duck_experiment{experiment="ndt.iupui"} != bool 1
         )
         """),
     'ndt_ssl_ipv6': textwrap.dedent("""\
         min by (experiment, machine) (
-          (
-            (
-              (probe_success{service="ndt_ssl_ipv6"}) +
-              ON (experiment, machine) (script_success{service="ndt_e2e"}) +
-              ON (experiment, machine) ((vdlimit_used{experiment="ndt.iupui"} /
-                  vdlimit_total{experiment="ndt.iupui"}) < bool 0.95) +
-              ON (experiment, machine)
-                (lame_duck_experiment{experiment="ndt.iupui"} != bool 1)
-            ) == bool 4
-          ) OR
-          ON(experiment, machine) probe_success{service="ndt_ssl_ipv6"}
-            UNLESS ON(machine) up{service="nodeexporter"} == 1
+            probe_success{service="ndt_ssl_ipv6"} OR
+            script_success{service="ndt_e2e"} OR
+            (vdlimit_used{experiment="ndt.iupui"} /
+              vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR
+            lame_duck_experiment{experiment="ndt.iupui"} != bool 1
         )
         """),
     'neubot': textwrap.dedent("""\
         min by (experiment, machine) (
-          (
-            (
-              (probe_success{service="neubot"}) +
-              ON (experiment, machine)
-                (lame_duck_experiment{experiment="neubot.mlab"} != bool 1)
-            ) == bool 2
-          ) OR
-          ON(experiment, machine) probe_success{service="neubot"}
-            UNLESS ON(machine) up{service="nodeexporter"} == 1
+            probe_success{service="neubot"} OR
+            lame_duck_experiment{experiment="neubot.mlab"} != bool 1
         )
         """),
     'neubot_ipv6': textwrap.dedent("""\
         min by (experiment, machine) (
-          (
-            (
-              (probe_success{service="neubot_ipv6"}) +
-              ON (experiment, machine)
-                (lame_duck_experiment{experiment="neubot.mlab"} != bool 1)
-            ) == bool 2
-          ) OR
-          ON(experiment, machine) probe_success{service="neubot_ipv6"}
-            UNLESS ON(machine) up{service="nodeexporter"} == 1
+            probe_success{service="neubot_ipv6"} OR
+            lame_duck_experiment{experiment="neubot.mlab"} != bool 1
         )
         """),
     'mobiperf': textwrap.dedent("""\
         min by (experiment, machine) (
-          (
-            (
-              (probe_success{service="mobiperf", instance=~".*:6001"}) +
-              ON (experiment, machine)
-                (probe_success{service="mobiperf", instance=~".*:6002"}) +
-              ON (experiment, machine)
-                (probe_success{service="mobiperf", instance=~".*:6003"}) +
-              ON (experiment, machine)
-                (lame_duck_experiment{experiment="1.michigan"} != bool 1)
-            ) == bool 4
-          ) OR
-          ON(experiment, machine) probe_success{service="mobiperf"}
-            UNLESS ON(machine) up{service="nodeexporter"} == 1
+            probe_success{service="mobiperf", instance=~".*:6001"} OR
+            probe_success{service="mobiperf", instance=~".*:6002"} OR
+            probe_success{service="mobiperf", instance=~".*:6003"} OR
+            lame_duck_experiment{experiment="1.michigan"} != bool 1
         )
         """),
     'mobiperf_ipv6': textwrap.dedent("""\
         min by (experiment, machine) (
-          (
-            (
-              (probe_success{service="mobiperf_ipv6", instance=~".*:6001"}) +
-              ON (experiment, machine)
-                (probe_success{service="mobiperf_ipv6", instance=~".*:6002"}) +
-              ON (experiment, machine)
-                (probe_success{service="mobiperf_ipv6", instance=~".*:6003"}) +
-              ON (experiment, machine)
-                (lame_duck_experiment{experiment="1.michigan"} != bool 1)
-            ) == bool 4
-          ) OR
-          ON(experiment, machine) probe_success{service="mobiperf_ipv6"}
-            UNLESS ON(machine) up{service="nodeexporter"} == 1
+            probe_success{service="mobiperf_ipv6", instance=~".*:6001"} OR
+            probe_success{service="mobiperf_ipv6", instance=~".*:6002"} OR
+            probe_success{service="mobiperf_ipv6", instance=~".*:6003"} OR
+            lame_duck_experiment{experiment="1.michigan"} != bool 1
         )
         """),
 }


### PR DESCRIPTION
After some thought and discussion, it was realized that the original form of the Prometheus queries is best. The current form of the queries attempts to be sure that if a metric is missing that timeseries row is still returned, with a value of zero. What this means is that when a metric is missing, the entire experiment will be flagged as down in mlab-ns. In the event there is an outage of some Prometheus service, causing a metric to disappear platform wide, this could potentially flag a tool down on the entire platform.

The old way of querying Prometheus, and the way in this PR, is to `OR` each metric we care about, and then see if any one of them equals zero. If one particular goes missing, then the other metrics should still return results, and status will be determined on the remaining metrics. If for some reason all metrics vanish, then no row will be returned at all, in which case mlab-ns will log that monitoring didn't return any results, and it will skip updating any status, leaving the current stale status.

The changes in the PR are running in mlab-nstesting.

**NOTE**: The [bug in these original queries](https://github.com/m-lab/mlab-ns/issues/143) is now handled by [a change in how we write lame duck files](https://github.com/m-lab/mlabops/pull/66).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/154)
<!-- Reviewable:end -->
