### PR TITLE
Changes is_production_site() regex to also match cloud VM sites like xyz0c.

### DIFF
--- a/server/mlabns/tests/test_production_check.py
+++ b/server/mlabns/tests/test_production_check.py
@@ -9,6 +9,7 @@ class CheckProductionTestCase(unittest.TestCase):
         self.assertTrue(pc.is_production_site('nuq01'))
         self.assertTrue(pc.is_production_site('nuq99'))
         self.assertTrue(pc.is_production_site('tun05'))
+        self.assertTrue(pc.is_production_site('lax0c'))
         self.assertTrue(
             pc.is_production_site('TUN05'),
             ('production style site names are considered production even when '

--- a/server/mlabns/util/production_check.py
+++ b/server/mlabns/util/production_check.py
@@ -10,6 +10,11 @@ def is_production_site(site_name):
     Returns:
         True if the site name matches the schema of a production site.
     """
+    # Regular platform site names match the pattern [a-z]{3}\d{2}, but we now
+    # have some cloud VMs that we use for special purposes on the platform, and
+    # these sites end with the letter "c" (for "cloud"), not unlike testing
+    # sites end in the letter "t". The following regex should match both regular
+    # platform nodes as well as cloud VMs.
     return re.match('^[a-z]{3}(\d{2}|\dc)$', site_name, re.IGNORECASE) != None
 
 

--- a/server/mlabns/util/production_check.py
+++ b/server/mlabns/util/production_check.py
@@ -10,7 +10,7 @@ def is_production_site(site_name):
     Returns:
         True if the site name matches the schema of a production site.
     """
-    return re.match('^[a-z]{3}\d{2}$', site_name, re.IGNORECASE) != None
+    return re.match('^[a-z]{3}(\d{2}|\dc)$', site_name, re.IGNORECASE) != None
 
 
 def is_production_slice(slice_fqdn):


### PR DESCRIPTION
Our new convention is to name cloud platform nodes by appending a `c` e.g., xyz0c, chs0c, lax0c, etc. Currently, mlab-ns filters sites that don't match `[a-z]{3}\d{2}`. This PR fixes that to also allow `[a-z]{3}\dc`.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/157)
<!-- Reviewable:end -->
