### PR TITLE
Takes into account GMX machine maintenance status in mlab-ns queries to Prometheus

### DIFF
--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -36,7 +36,7 @@ QUERIES = {
             (vdlimit_used{experiment="ndt.iupui"} /
               vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR
             lame_duck_experiment{experiment="ndt.iupui"} != bool 1 OR
-            label_replace(gmx_machine_maintenance{machine=~"mlab[1-3].*"}, "experiment", "ndt.iupui", "", "") != bool 1
+            label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
         )
         """),
     'ndt_ipv6': textwrap.dedent("""\
@@ -46,7 +46,7 @@ QUERIES = {
             (vdlimit_used{experiment="ndt.iupui"} /
               vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR
             lame_duck_experiment{experiment="ndt.iupui"} != bool 1 OR
-            label_replace(gmx_machine_maintenance{machine=~"mlab[1-3].*"}, "experiment", "ndt.iupui", "", "") != bool 1
+            label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
         )
         """),
     'ndt_ssl': textwrap.dedent("""\
@@ -56,7 +56,7 @@ QUERIES = {
             (vdlimit_used{experiment="ndt.iupui"} /
               vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR
             lame_duck_experiment{experiment="ndt.iupui"} != bool 1 OR
-            label_replace(gmx_machine_maintenance{machine=~"mlab[1-3].*"}, "experiment", "ndt.iupui", "", "") != bool 1
+            label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
         )
         """),
     'ndt_ssl_ipv6': textwrap.dedent("""\
@@ -66,21 +66,21 @@ QUERIES = {
             (vdlimit_used{experiment="ndt.iupui"} /
               vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR
             lame_duck_experiment{experiment="ndt.iupui"} != bool 1 OR
-            label_replace(gmx_machine_maintenance{machine=~"mlab[1-3].*"}, "experiment", "ndt.iupui", "", "") != bool 1
+            label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
         )
         """),
     'neubot': textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="neubot"} OR
             lame_duck_experiment{experiment="neubot.mlab"} != bool 1 OR
-            label_replace(gmx_machine_maintenance{machine=~"mlab[1-3].*"}, "experiment", "neubot.mlab", "", "") != bool 1
+            label_replace(gmx_machine_maintenance, "experiment", "neubot.mlab", "", "") != bool 1
         )
         """),
     'neubot_ipv6': textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="neubot_ipv6"} OR
             lame_duck_experiment{experiment="neubot.mlab"} != bool 1 OR
-            label_replace(gmx_machine_maintenance{machine=~"mlab[1-3].*"}, "experiment", "neubot.mlab", "", "") != bool 1
+            label_replace(gmx_machine_maintenance, "experiment", "neubot.mlab", "", "") != bool 1
         )
         """),
     'mobiperf': textwrap.dedent("""\
@@ -89,7 +89,7 @@ QUERIES = {
             probe_success{service="mobiperf", instance=~".*:6002"} OR
             probe_success{service="mobiperf", instance=~".*:6003"} OR
             lame_duck_experiment{experiment="1.michigan"} != bool 1 OR
-            label_replace(gmx_machine_maintenance{machine=~"mlab[1-3].*"}, "experiment", "1.michigan", "", "") != bool 1
+            label_replace(gmx_machine_maintenance, "experiment", "1.michigan", "", "") != bool 1
         )
         """),
     'mobiperf_ipv6': textwrap.dedent("""\
@@ -98,7 +98,7 @@ QUERIES = {
             probe_success{service="mobiperf_ipv6", instance=~".*:6002"} OR
             probe_success{service="mobiperf_ipv6", instance=~".*:6003"} OR
             lame_duck_experiment{experiment="1.michigan"} != bool 1 OR
-            label_replace(gmx_machine_maintenance{machine=~"mlab[1-3].*"}, "experiment", "1.michigan", "", "") != bool 1
+            label_replace(gmx_machine_maintenance, "experiment", "1.michigan", "", "") != bool 1
         )
         """),
 }

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -22,6 +22,12 @@ from mlabns.util import message
 # probe_success), something will need to be done to make sure that the label
 # sets are unique for each metric, even if it means using label_replace() in
 # these queries.
+#
+# The label_replace() function is necessary on the gmx_machine_maintenance
+# metrics because the GMX has no concept of "experiment", yet this label is
+# required for the query, and, more importantly, the output of the query to work
+# as intended. label_replace() here just manually adds the experiment label to
+# every result with a static value.
 QUERIES = {
     'ndt': textwrap.dedent("""\
         min by (experiment, machine) (
@@ -29,7 +35,8 @@ QUERIES = {
             script_success{service="ndt_e2e"} OR
             (vdlimit_used{experiment="ndt.iupui"} /
               vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR
-            lame_duck_experiment{experiment="ndt.iupui"} != bool 1
+            lame_duck_experiment{experiment="ndt.iupui"} != bool 1 OR
+            label_replace(gmx_machine_maintenance{machine=~"mlab[1-3].*"}, "experiment", "ndt.iupui", "", "") != bool 1
         )
         """),
     'ndt_ipv6': textwrap.dedent("""\
@@ -38,7 +45,8 @@ QUERIES = {
             script_success{service="ndt_e2e"} OR
             (vdlimit_used{experiment="ndt.iupui"} /
               vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR
-            lame_duck_experiment{experiment="ndt.iupui"} != bool 1
+            lame_duck_experiment{experiment="ndt.iupui"} != bool 1 OR
+            label_replace(gmx_machine_maintenance{machine=~"mlab[1-3].*"}, "experiment", "ndt.iupui", "", "") != bool 1
         )
         """),
     'ndt_ssl': textwrap.dedent("""\
@@ -47,7 +55,8 @@ QUERIES = {
             script_success{service="ndt_e2e"} OR
             (vdlimit_used{experiment="ndt.iupui"} /
               vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR
-            lame_duck_experiment{experiment="ndt.iupui"} != bool 1
+            lame_duck_experiment{experiment="ndt.iupui"} != bool 1 OR
+            label_replace(gmx_machine_maintenance{machine=~"mlab[1-3].*"}, "experiment", "ndt.iupui", "", "") != bool 1
         )
         """),
     'ndt_ssl_ipv6': textwrap.dedent("""\
@@ -56,19 +65,22 @@ QUERIES = {
             script_success{service="ndt_e2e"} OR
             (vdlimit_used{experiment="ndt.iupui"} /
               vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR
-            lame_duck_experiment{experiment="ndt.iupui"} != bool 1
+            lame_duck_experiment{experiment="ndt.iupui"} != bool 1 OR
+            label_replace(gmx_machine_maintenance{machine=~"mlab[1-3].*"}, "experiment", "ndt.iupui", "", "") != bool 1
         )
         """),
     'neubot': textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="neubot"} OR
-            lame_duck_experiment{experiment="neubot.mlab"} != bool 1
+            lame_duck_experiment{experiment="neubot.mlab"} != bool 1 OR
+            label_replace(gmx_machine_maintenance{machine=~"mlab[1-3].*"}, "experiment", "neubot.mlab", "", "") != bool 1
         )
         """),
     'neubot_ipv6': textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="neubot_ipv6"} OR
-            lame_duck_experiment{experiment="neubot.mlab"} != bool 1
+            lame_duck_experiment{experiment="neubot.mlab"} != bool 1 OR
+            label_replace(gmx_machine_maintenance{machine=~"mlab[1-3].*"}, "experiment", "neubot.mlab", "", "") != bool 1
         )
         """),
     'mobiperf': textwrap.dedent("""\
@@ -76,7 +88,8 @@ QUERIES = {
             probe_success{service="mobiperf", instance=~".*:6001"} OR
             probe_success{service="mobiperf", instance=~".*:6002"} OR
             probe_success{service="mobiperf", instance=~".*:6003"} OR
-            lame_duck_experiment{experiment="1.michigan"} != bool 1
+            lame_duck_experiment{experiment="1.michigan"} != bool 1 OR
+            label_replace(gmx_machine_maintenance{machine=~"mlab[1-3].*"}, "experiment", "1.michigan", "", "") != bool 1
         )
         """),
     'mobiperf_ipv6': textwrap.dedent("""\
@@ -84,7 +97,8 @@ QUERIES = {
             probe_success{service="mobiperf_ipv6", instance=~".*:6001"} OR
             probe_success{service="mobiperf_ipv6", instance=~".*:6002"} OR
             probe_success{service="mobiperf_ipv6", instance=~".*:6003"} OR
-            lame_duck_experiment{experiment="1.michigan"} != bool 1
+            lame_duck_experiment{experiment="1.michigan"} != bool 1 OR
+            label_replace(gmx_machine_maintenance{machine=~"mlab[1-3].*"}, "experiment", "1.michigan", "", "") != bool 1
         )
         """),
 }


### PR DESCRIPTION
mlab-ns currently doesn't not take into account GMX maintenance status when determining whether an experiment is up or down. This PR modifies the PromQL to take into account GMX maintenance status, since we really don't want to be sending production traffic to machines that we have flagged as being in maintenance mode.

One important caveat to this is that this does not account for site maintenance. The original intention behind site maintenance was marking all hardware at a site as in maintenance mode in one shot, without the need to manually put every single node into maintenance.  However, this doesn't translate well to these sorts of queries that fundamentally rely on the concept of a machine.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/167)
<!-- Reviewable:end -->
