### PR TITLE
Enable warmup handler, and define service name in mlab-staging

### DIFF
--- a/server/app.yaml.mlab-staging
+++ b/server/app.yaml.mlab-staging
@@ -2,6 +2,7 @@ runtime: python27
 api_version: 1
 threadsafe: false
 instance_class: F4_1G
+service: locate
 
 handlers:
 
@@ -37,6 +38,10 @@ handlers:
 - url: /.*
   script: main.app
 
+- url: /_ah/warmup
+  script: main.py
+  login: admin
+
 builtins:
 - appstats: on
 - deferred: on
@@ -54,3 +59,9 @@ libraries:
 
 includes:
 - mapreduce/include.yaml
+
+env_variables:
+  SERVER_REGEX: "^mlab4$"
+
+inbound_services:
+- warmup


### PR DESCRIPTION
This change completes a configuration for mlab-staging that was accidentally missed in https://github.com/m-lab/mlab-ns/pull/170

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/171)
<!-- Reviewable:end -->
