### PR TITLE
Imports util.redirect module and calls try_redirect_url from that import

### DIFF
--- a/server/mlabns/handlers/lookup.py
+++ b/server/mlabns/handlers/lookup.py
@@ -7,6 +7,7 @@ from mlabns.db import model
 from mlabns.util import fqdn_rewrite
 from mlabns.util import lookup_query
 from mlabns.util import message
+from mlabns.util import redirect
 from mlabns.util import resolver
 from mlabns.util import util
 
@@ -45,7 +46,7 @@ class LookupHandler(webapp.RequestHandler):
         in the query string, see the design doc at http://goo.gl/48S22.
         """
         # Check right away whether we should redirect this request.
-        url = util.try_redirect_url(self.request, datetime.datetime.now())
+        url = redirect.try_redirect_url(self.request, datetime.datetime.now())
         if url:
             return self.send_redirect_url(url)
 


### PR DESCRIPTION
Previously, the call was being made to `util.util.try_redirect_url()`, but `try_redirect_url()` is actually located in the `util.redirect` module. This PR fixes that.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/173)
<!-- Reviewable:end -->
