### PR TITLE
Add location summary logging and remove remaining mlab-nstesting

### DIFF
--- a/compare_instances.py
+++ b/compare_instances.py
@@ -36,7 +36,7 @@ def parse_options(args):
     parser.add_argument(
         '--instance_two_url',
         dest='instance_two_url',
-        default='http://mlab-nstesting.appspot.com',
+        default='http://locate-dot-mlab-staging.appspot.com',
         help='Base URL for the second mlab-ns instance to query.')
     parser.add_argument('--tool_id',
                         dest='tool_id',

--- a/server/app.yaml.mlab-sandbox
+++ b/server/app.yaml.mlab-sandbox
@@ -61,7 +61,7 @@ includes:
 - mapreduce/include.yaml
 
 env_variables:
-  # SERVER_REGEX: "^mlab4$"
+  SERVER_REGEX: "^mlab4$"
   IGNORE_BUSINESS_HOURS: "1"
 
 inbound_services:

--- a/server/app.yaml.mlab-sandbox
+++ b/server/app.yaml.mlab-sandbox
@@ -61,7 +61,7 @@ includes:
 - mapreduce/include.yaml
 
 env_variables:
-  SERVER_REGEX: "^mlab4$"
+  # SERVER_REGEX: "^mlab4$"
   IGNORE_BUSINESS_HOURS: "1"
 
 inbound_services:

--- a/server/mlabns/handlers/lookup.py
+++ b/server/mlabns/handlers/lookup.py
@@ -369,7 +369,7 @@ class LookupHandler(webapp.RequestHandler):
                      str(query.distance))
 
     def log_location(self, query, sliver_tools):
-        """Logs the client location Country & City."""
+        """Logs the client Country and compares Maxmind to AppEngine distance"""
         if query.tool_id != 'ndt_ssl':
             logging.info('wrong-tool_id: %s', query.tool_id)
             return

--- a/server/mlabns/handlers/lookup.py
+++ b/server/mlabns/handlers/lookup.py
@@ -235,10 +235,9 @@ class LookupHandler(webapp.RequestHandler):
         Args:
           url: str, URL to direct client.
         """
-        if url.index(':') != self.request.url.index(':'):
-            logging.info("Resetting redirect protocol to match origin.")
-            url = (self.request.url[:self.request.url.index(':')] +
-                   url[url.index(':'):])
+        if url.index(':') != len(self.requet.scheme):
+            logging.info("Resetting redirect scheme to match origin.")
+            url = (self.request.scheme + url[url.index(':'):])
         self.redirect(str(url))
 
     def send_map_response(self, sliver_tool, query, candidates):
@@ -383,6 +382,7 @@ class LookupHandler(webapp.RequestHandler):
             logging.info('not using appengine geoloc')
             return
 
+        # Log client country to display geomap summaries of client origins.
         logging.info('[client.country],%s', query.country)
 
         # Log only the first returned site (this is random but makes log
@@ -406,10 +406,10 @@ class LookupHandler(webapp.RequestHandler):
             sliver_tool.latitude, sliver_tool.longitude,
             query._maxmind_latitude, query._maxmind_longitude)
 
-        logging.info('[nearest.site],%s', sliver_tool.site_id)
-        logging.info(('[server.distance],{tool_id},{site_id},{country},'
+        logging.info(('[server.distance],{scheme},{tool_id},{site_id},{country},'
                       '{city},{geo_type},{dist_appengine},'
                       '{dist_maxmind},{difference}').format(
+                          scheme=self.request.scheme,
                           tool_id=query.tool_id,
                           site_id=sliver_tool.site_id,
                           country=sliver_tool.country,

--- a/server/mlabns/handlers/lookup.py
+++ b/server/mlabns/handlers/lookup.py
@@ -376,6 +376,10 @@ class LookupHandler(webapp.RequestHandler):
             logging.info('wrong sliver_tools type: %s', len(sliver_tools))
             return
 
+        if query._geolocation_type != constants.GEOLOCATION_APP_ENGINE:
+            logging.info('not using appengine geoloc')
+            return
+
         # Log only the first returned site (this is random but makes log
         # analysis easier than multiple lines).
         sliver_tool = sliver_tools[0]

--- a/server/mlabns/handlers/lookup.py
+++ b/server/mlabns/handlers/lookup.py
@@ -369,9 +369,11 @@ class LookupHandler(webapp.RequestHandler):
     def log_location(self, query, sliver_tools):
         """Logs the client location Country & City."""
         if query.tool_id != 'ndt_ssl':
+            logging.info('wrong-tool_id: %s', query.tool_id)
             return
 
         if type(sliver_tools) != list or not sliver_tools:
+            logging.info('wrong sliver_tools type: %s', len(sliver_tools))
             return
 
         # Log only the first returned site (this is random but makes log

--- a/server/mlabns/handlers/lookup.py
+++ b/server/mlabns/handlers/lookup.py
@@ -387,7 +387,7 @@ class LookupHandler(webapp.RequestHandler):
 
         # Calculate the difference between the two systems.
         difference = distance.distance(
-            query._gae_latitude, query._gae_longitude)
+            query._gae_latitude, query._gae_longitude,
             query._maxmind_latitude, query._maxmind_longitude)
 
         # Calculate the server-to-client distance for AppEngine & Maxmind.

--- a/server/mlabns/handlers/lookup.py
+++ b/server/mlabns/handlers/lookup.py
@@ -371,26 +371,26 @@ class LookupHandler(webapp.RequestHandler):
     def log_location(self, query, sliver_tools):
         """Logs the client Country and compares Maxmind to AppEngine distance"""
         if query.tool_id != 'ndt_ssl':
-            logging.info('wrong-tool_id: %s', query.tool_id)
+            # We only want to look at ndt_ssl clients for now.
             return
 
         if type(sliver_tools) != list or not sliver_tools:
-            logging.info('wrong sliver_tools type: %s', len(sliver_tools))
+            logging.info('unexpected sliver_tools type: %s', len(sliver_tools))
             return
 
         if query._geolocation_type != constants.GEOLOCATION_APP_ENGINE:
-            logging.info('not using appengine geoloc')
+            # We cannot compare AppEngine location to Maxmind in this case.
             return
+
+        t0 = datetime.datetime.now()
 
         # Log client country to display geomap summaries of client origins.
         logging.info('[client.country],%s', query.country)
 
-        # Log only the first returned site (this is random but makes log
-        # analysis easier than multiple lines).
+        # Log only the first (closest) site.
         sliver_tool = sliver_tools[0]
 
-        t0 = datetime.datetime.now()
-        # Lookup the maxmind information also.
+        # Lookup the maxmind information.
         query._set_maxmind_geolocation(query.ip_address, None, None)
 
         # Calculate the difference between the two systems.

--- a/server/mlabns/handlers/lookup.py
+++ b/server/mlabns/handlers/lookup.py
@@ -4,6 +4,7 @@ import logging
 import time
 
 from mlabns.db import model
+from mlabns.util import constants
 from mlabns.util import distance
 from mlabns.util import fqdn_rewrite
 from mlabns.util import lookup_query

--- a/server/mlabns/handlers/lookup.py
+++ b/server/mlabns/handlers/lookup.py
@@ -235,7 +235,7 @@ class LookupHandler(webapp.RequestHandler):
         Args:
           url: str, URL to direct client.
         """
-        if url.index(':') != len(self.requet.scheme):
+        if url.index(':') != len(self.request.scheme):
             logging.info("Resetting redirect scheme to match origin.")
             url = (self.request.scheme + url[url.index(':'):])
         self.redirect(str(url))
@@ -406,18 +406,19 @@ class LookupHandler(webapp.RequestHandler):
             sliver_tool.latitude, sliver_tool.longitude,
             query._maxmind_latitude, query._maxmind_longitude)
 
-        logging.info(('[server.distance],{scheme},{tool_id},{site_id},{country},'
-                      '{city},{geo_type},{dist_appengine},'
-                      '{dist_maxmind},{difference}').format(
-                          scheme=self.request.scheme,
-                          tool_id=query.tool_id,
-                          site_id=sliver_tool.site_id,
-                          country=sliver_tool.country,
-                          city=sliver_tool.city,
-                          geo_type=query._geolocation_type,
-                          dist_appengine=dist_appengine,
-                          dist_maxmind=dist_maxmind,
-                          difference=difference))
+        logging.info((
+            '[server.distance],{scheme},{tool_id},{site_id},{country},'
+            '{city},{geo_type},{dist_appengine},'
+            '{dist_maxmind},{difference}').format(
+                scheme=self.request.scheme,
+                tool_id=query.tool_id,
+                site_id=sliver_tool.site_id,
+                country=sliver_tool.country,
+                city=sliver_tool.city,
+                geo_type=query._geolocation_type,
+                dist_appengine=dist_appengine,
+                dist_maxmind=dist_maxmind,
+                difference=difference))
 
         t1 = datetime.datetime.now()
         logging.info('[log_location.delay],{delay}'.format(delay=str((

--- a/server/mlabns/handlers/lookup.py
+++ b/server/mlabns/handlers/lookup.py
@@ -52,7 +52,6 @@ class LookupHandler(webapp.RequestHandler):
         if url:
             logging.info('[redirect],true,%s', url)
             return self.send_redirect_url(url)
-        logging.info('[redirect],false,')
 
         query = lookup_query.LookupQuery()
         query.initialize_from_http_request(self.request)
@@ -398,26 +397,15 @@ class LookupHandler(webapp.RequestHandler):
             query._gae_latitude, query._gae_longitude, query._maxmind_latitude,
             query._maxmind_longitude)
 
-        # Calculate the server-to-client distance for AppEngine & Maxmind.
-        dist_appengine = distance.distance(
-            sliver_tool.latitude, sliver_tool.longitude, query._gae_latitude,
-            query._gae_longitude)
-        dist_maxmind = distance.distance(
-            sliver_tool.latitude, sliver_tool.longitude,
-            query._maxmind_latitude, query._maxmind_longitude)
-
         logging.info((
             '[server.distance],{scheme},{tool_id},{site_id},{country},'
-            '{city},{geo_type},{dist_appengine},'
-            '{dist_maxmind},{difference}').format(
+            '{city},{same_country},{difference}').format(
                 scheme=self.request.scheme,
                 tool_id=query.tool_id,
                 site_id=sliver_tool.site_id,
                 country=sliver_tool.country,
                 city=sliver_tool.city,
-                geo_type=query._geolocation_type,
-                dist_appengine=dist_appengine,
-                dist_maxmind=dist_maxmind,
+                same_country=(query._gae_country == query._maxmind_country),
                 difference=difference))
 
         t1 = datetime.datetime.now()

--- a/server/mlabns/handlers/lookup.py
+++ b/server/mlabns/handlers/lookup.py
@@ -382,34 +382,33 @@ class LookupHandler(webapp.RequestHandler):
 
         t0 = datetime.datetime.now()
         # Lookup the maxmind information also.
-        query._set_maxmind_geolocation(
-            query.ip_address, query.country, query.city)
+        query._set_maxmind_geolocation(query.ip_address, query.country,
+                                       query.city)
 
         # Calculate the difference between the two systems.
         difference = distance.distance(
-            query._gae_latitude, query._gae_longitude,
-            query._maxmind_latitude, query._maxmind_longitude)
+            query._gae_latitude, query._gae_longitude, query._maxmind_latitude,
+            query._maxmind_longitude)
 
         # Calculate the server-to-client distance for AppEngine & Maxmind.
         dist_appengine = distance.distance(
-            sliver_tool.latitude, sliver_tool.longitude,
-            query._gae_latitude, query._gae_longitude)
+            sliver_tool.latitude, sliver_tool.longitude, query._gae_latitude,
+            query._gae_longitude)
         dist_maxmind = distance.distance(
             sliver_tool.latitude, sliver_tool.longitude,
             query._maxmind_latitude, query._maxmind_longitude)
 
-        logging.info(
-            ('[server.distance],{tool_id},{site_id},{country},'
-             '{city},{geo_type},{dist_appengine},'
-             '{dist_maxmind},{difference}').format(
-                tool_id=query.tool_id,
-                site_id=sliver_tool.site_id,
-                country=sliver_tool.country,
-                city=sliver_tool.city,
-                geo_type=query._geolocation_type,
-                dist_appengine=dist_appengine,
-                dist_maxmind=dist_maxmind,
-                difference=difference))
+        logging.info(('[server.distance],{tool_id},{site_id},{country},'
+                      '{city},{geo_type},{dist_appengine},'
+                      '{dist_maxmind},{difference}').format(
+                          tool_id=query.tool_id,
+                          site_id=sliver_tool.site_id,
+                          country=sliver_tool.country,
+                          city=sliver_tool.city,
+                          geo_type=query._geolocation_type,
+                          dist_appengine=dist_appengine,
+                          dist_maxmind=dist_maxmind,
+                          difference=difference))
 
         t1 = datetime.datetime.now()
-        logging.info('[log_location.delay],{delay}'.format(delay=str(t1-t0)))
+        logging.info('[log_location.delay],{delay}'.format(delay=str(t1 - t0)))

--- a/server/mlabns/handlers/lookup.py
+++ b/server/mlabns/handlers/lookup.py
@@ -400,8 +400,8 @@ class LookupHandler(webapp.RequestHandler):
 
         logging.info(
             ('[server.distance],{tool_id},{site_id},{country},'
-             '{city},{geo_type},{distance_appengine},'
-             '{distance_maxmind},{difference}').format(
+             '{city},{geo_type},{dist_appengine},'
+             '{dist_maxmind},{difference}').format(
                 tool_id=query.tool_id,
                 site_id=sliver_tool.site_id,
                 country=sliver_tool.country,

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -37,8 +37,8 @@ class SiteRegistrationHandler(webapp.RequestHandler):
 
     REQUIRED_FIELDS = [SITE_FIELD, METRO_FIELD, CITY_FIELD, COUNTRY_FIELD,
                        LAT_FIELD, LON_FIELD, ROUNDROBIN_FIELD]
-    SITE_LIST_URL = 'https://storage.googleapis.com/operator-mlab-oti/metadata/v0/current/mlab-site-stats.json'
-    TESTING_SITE_LIST_URL = 'https://storage.googleapis.com/operator-mlab-sandbox/metadata/v0/current/mlab-site-stats.json'
+    DEFAULT_SITE_LIST_URL = 'https://storage.googleapis.com/operator-mlab-oti/metadata/v0/current/mlab-site-stats.json'
+    TEMPLATE_SITE_LIST_URL = 'https://storage.googleapis.com/operator-{project}/metadata/v0/current/mlab-site-stats.json'
 
     @classmethod
     def _is_valid_site(cls, site):
@@ -71,10 +71,11 @@ class SiteRegistrationHandler(webapp.RequestHandler):
         """
         try:
             project = app_identity.get_application_id()
-            if project == 'mlab-nstesting':
-                json_file = self.TESTING_SITE_LIST_URL
+            if project == 'mlab-ns':
+                # TODO: eliminate project translation.
+                json_file = self.DEFAULT_SITE_LIST_URL
             else:
-                json_file = self.SITE_LIST_URL
+                json_file = self.TEMPLATE_SITE_LIST_URL.format(project=project)
         except AttributeError:
             logging.error('Cannot get project name.')
             return util.send_not_found(self)
@@ -166,8 +167,8 @@ class SiteRegistrationHandler(webapp.RequestHandler):
 class IPUpdateHandler():
     """Updates SliverTools' IP addresses."""
 
-    IP_LIST_URL = 'https://storage.googleapis.com/operator-mlab-oti/metadata/v0/current/mlab-host-ips.txt'
-    TESTING_IP_LIST_URL = 'https://storage.googleapis.com/operator-mlab-sandbox/metadata/v0/current/mlab-host-ips.txt'
+    DEFAULT_IP_LIST_URL = 'https://storage.googleapis.com/operator-mlab-oti/metadata/v0/current/mlab-host-ips.txt'
+    TEMPLATE_IP_LIST_URL = 'https://storage.googleapis.com/operator-{project}/metadata/v0/current/mlab-host-ips.txt'
 
     def update(self):
         """Triggers the update handler.
@@ -177,10 +178,11 @@ class IPUpdateHandler():
         lines = []
         try:
             project = app_identity.get_application_id()
-            if project == 'mlab-nstesting':
-                host_ips_url = self.TESTING_IP_LIST_URL
+            if project == 'mlab-ns':
+                # TODO: eliminate project translation.
+                host_ips_url = self.DEFAULT_IP_LIST_URL
             else:
-                host_ips_url = self.IP_LIST_URL
+                host_ips_url = self.TEMPLATE_IP_LIST_URL.format(project=project)
         except AttributeError:
             logging.error('Cannot get project name.')
             return util.send_not_found(self)

--- a/server/mlabns/tests/test_lookup.py
+++ b/server/mlabns/tests/test_lookup.py
@@ -32,6 +32,7 @@ class LookupTest(unittest2.TestCase):
             self.response = mock.Mock()
             self.error_code = None
             self.url = url
+            self.scheme = url[:url.index(':')]
             self.path = path
             self.path_qs = path
             self.uri = url

--- a/server/mlabns/tests/test_lookup.py
+++ b/server/mlabns/tests/test_lookup.py
@@ -1,7 +1,9 @@
 import mock
 import unittest2
 
+from mlabns.db import model
 from mlabns.handlers import lookup
+from mlabns.util import constants
 from mlabns.util import redirect
 
 
@@ -48,6 +50,26 @@ class LookupTest(unittest2.TestCase):
         h.get()
 
         self.assertEqual(h.response.code, 302)
+
+    def test_log_location(self):
+        h = lookup.LookupHandler()
+        h.request = LookupTest.RequestMockup(url='https://mlab-ns.appspot.com',
+                                             path='/ndt_ssl')
+        h.response = LookupTest.ResponseMockup()
+        query = mock.Mock()
+        query.tool_id = 'ndt_ssl'
+        # Place lat/lon at known distances apart and from server.
+        query._gae_latitude, query._gae_longitude = (0.0, 1.0)
+        query._maxmind_latitude, query._maxmind_longitude = (0.0, 2.0)
+        query._geolocation_type = constants.GEOLOCATION_APP_ENGINE
+        sliver_tools = [model.SliverTool(tool_id='ndt_ssl',
+                                         site_id='foo01',
+                                         country='US',
+                                         city='New_York',
+                                         latitude=0.0,
+                                         longitude=0.0)]
+
+        h.log_location(query, sliver_tools)
 
 
 if __name__ == '__main__':

--- a/server/mlabns/tests/test_update.py
+++ b/server/mlabns/tests/test_update.py
@@ -57,7 +57,7 @@ class SiteRegistrationHandlerTest(unittest2.TestCase):
     "roundrobin": false
 }
 ]""")
-        app_identity.get_application_id.return_value = 'mlab-nstesting'
+        app_identity.get_application_id.return_value = 'mlab-testing'
         db.Query.fetch.return_value = [mock.Mock(site_id='xyz01')]
         handler = update.SiteRegistrationHandler()
         handler.get()
@@ -81,7 +81,7 @@ class SiteRegistrationHandlerTest(unittest2.TestCase):
     "roundrobin": false
 }
 ]""")
-        app_identity.get_application_id.return_value = 'mlab-nstesting'
+        app_identity.get_application_id.return_value = 'mlab-testing'
         db.Query.fetch.return_value = [mock.Mock(site_id='xyz01')]
         handler = update.SiteRegistrationHandler()
         handler.get()


### PR DESCRIPTION
This change adds a new logging function to typical mlab-ns queries that reports the client country and metrics comparing the Maxmind and AppEngine geoloc databases without logging specific client location information: client-to-server for maxmind and appengine, and the difference between client locations.

As well, this change removes remaining references to mlab-nstesting in favor of sandbox or staging.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/175)
<!-- Reviewable:end -->
