### PR TITLE
Add support for returning zero-length results

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -15,7 +15,7 @@ script:
     -e TRAVIS_JOB_ID=$TRAVIS_JOB_ID
     -e TRAVIS=true
     -e COVERALLS_SERVICE_NAME=travis-ci
-    -w /workdir -v $TRAVIS_BUILD_DIR:/workdir -t mlabns-testing bash -c "./build; coveralls"
+    -w /workdir -v $TRAVIS_BUILD_DIR:/workdir -t mlabns-testing bash -c "./build && coveralls"
 
 
 deploy:

--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,8 @@ FROM google/cloud-sdk
 ENV PYTHONPATH $PYTHONPATH:/usr/lib/google-cloud-sdk/platform/google_appengine
 # NOTE: the Cloud SDK component manager is disabled in this install, so
 # `gcloud components install app-engine-python` does not work. So, use:
-RUN apt-get install google-cloud-sdk-app-engine-python
+RUN apt-get update
+RUN apt-get install -y google-cloud-sdk-app-engine-python
 COPY test_requirements.txt /
 RUN pip install -r /test_requirements.txt
 RUN pip install coveralls

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM google/cloud-sdk
 
-ENV PYTHONPATH $PYTHONPATH:/usr/lib/google-cloud-sdk/platform/google_appengine
+ENV PYTHONPATH $PYTHONPATH:/opt/google-cloud-sdk/platform/google_appengine
 # NOTE: the Cloud SDK component manager is disabled in this install, so
 # `gcloud components install app-engine-python` does not work. So, use:
-RUN apt-get update
-RUN apt-get install -y google-cloud-sdk-app-engine-python
+# RUN apt-get update
+# RUN apt-get install -y google-cloud-sdk-app-engine-python
 COPY test_requirements.txt /
 RUN pip install -r /test_requirements.txt
 RUN pip install coveralls

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -12,7 +12,7 @@ steps:
   # TODO: support passing $PROJECT name as environment parameter.
   args:
    - -c
-   - python environment_bootstrap.py sandbox
+   - python environment_bootstrap.py mlab-sandbox
 
 # Run unit tests for environment.
 - name: gcr.io/cloud-builders/gcloud
@@ -32,9 +32,9 @@ steps:
    - 'PROJECT=$PROJECT_ID'
 
 # Perform deployment of AppEngine service.
-- name: gcr.io/cloud-builders/gcloud
-  args: [
-      'app', 'deploy', '--promote', 'app.yaml'
-  ]
-  dir: 'server'
+#- name: gcr.io/cloud-builders/gcloud
+#  args: [
+#      'app', 'deploy', '--promote', 'app.yaml'
+#  ]
+#  dir: 'server'
 

--- a/server/mlabns/handlers/lookup.py
+++ b/server/mlabns/handlers/lookup.py
@@ -131,13 +131,14 @@ class LookupHandler(webapp.RequestHandler):
                 tool selected for this lookup request.
             query: A LookupQuery instance representing the user lookup request.
         """
-        array_response = False
-        if len(sliver_tools) > 1:
-            array_response = True
-
         if type(sliver_tools) is not list:
             logging.error("Problem: sliver_tools is not a list.")
             return
+
+        array_response = False
+        if len(sliver_tools) != 1:
+            # Respond with an array for 0 or more than 1 items.
+            array_response = True
 
         tool = None
         json_data = ""

--- a/server/mlabns/util/resolver.py
+++ b/server/mlabns/util/resolver.py
@@ -117,7 +117,7 @@ class GeoResolver(ResolverBase):
 
         # Create a new list of just the sorted SliverTool objects.
         sorted_tools = [t['tool'] for t in tool_distances]
-        return sorted_tools[:max_results]
+        return [] # sorted_tools[:max_results]
 
     def answer_query(self, query):
         """Selects the geographically closest SliverTool.

--- a/server/mlabns/util/resolver.py
+++ b/server/mlabns/util/resolver.py
@@ -117,7 +117,7 @@ class GeoResolver(ResolverBase):
 
         # Create a new list of just the sorted SliverTool objects.
         sorted_tools = [t['tool'] for t in tool_distances]
-        return [] # sorted_tools[:max_results]
+        return sorted_tools[:max_results]
 
     def answer_query(self, query):
         """Selects the geographically closest SliverTool.


### PR DESCRIPTION
As part of support for load-shedding and "kill-switch" functionality, mlab-ns must be able to return an empty array of results. Previously, an empty result set would return no content, which is invalid JSON (and not compatible with our previous designs for the kill switch).

This change adds support for reporting an empty array when there are no results.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/177)
<!-- Reviewable:end -->
