### PR TITLE
Support empty User-Agents and zero probability

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,10 @@
 FROM google/cloud-sdk
 
-ENV PYTHONPATH $PYTHONPATH:/opt/google-cloud-sdk/platform/google_appengine
+ENV PYTHONPATH $PYTHONPATH:/usr/lib/google-cloud-sdk/platform/google_appengine
 # NOTE: the Cloud SDK component manager is disabled in this install, so
 # `gcloud components install app-engine-python` does not work. So, use:
-# RUN apt-get update
-# RUN apt-get install -y google-cloud-sdk-app-engine-python
+RUN apt-get update
+RUN apt-get install -y google-cloud-sdk-app-engine-python
 COPY test_requirements.txt /
 RUN pip install -r /test_requirements.txt
 RUN pip install coveralls

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -6,27 +6,17 @@ timeout: 1800s
 ############################################################################
 
 steps:
-# Setup per-project configuration.
-- name: gcr.io/cloud-builders/gcloud
-  entrypoint: bash
-  # TODO: support passing $PROJECT name as environment parameter.
-  args:
-   - -c
-   - python environment_bootstrap.py mlab-sandbox
+# Create the image for testing mlab-ns.
+- name: gcr.io/cloud-builders/docker
+  args: [
+    'build', '-t', 'mlabns-tester', '.'
+  ]
 
 # Run unit tests for environment.
-- name: gcr.io/cloud-builders/gcloud
-  entrypoint: bash
-  args:
-   - -c
-   - >
-     pip install setuptools &&
-     pip install -r test_requirements.txt &&
-     pip install coveralls &&
-     /workspace/build
-
+- name: mlabns-tester
+  # "build" runs all unit tests.
+  entrypoint: /workspace/build
   env:
-   - 'PYTHONPATH=/builder/google-cloud-sdk/platform/google_appengine'
    - 'COMMIT=$COMMIT_SHA'
    - 'TAG=$TAG_NAME'
    - 'PROJECT=$PROJECT_ID'

--- a/server/mlabns/db/client_signature_fetcher.py
+++ b/server/mlabns/db/client_signature_fetcher.py
@@ -24,6 +24,7 @@ class ClientSignatureFetcher(object):
         """
         matched_requests = memcache.get(
             key, namespace=constants.MEMCACHE_NAMESPACE_REQUESTS)
-        if matched_requests:
+        # NB: allow probability to equal zero.
+        if matched_requests is not None:
             return matched_requests
         return 1.0

--- a/server/mlabns/util/lookup_query.py
+++ b/server/mlabns/util/lookup_query.py
@@ -316,6 +316,7 @@ class LookupQuery:
             A client signature if the request has ip_address, user_agent, tool_id
             and policy. Otherwise, returns an empty string.
         """
-        if self.ip_address and self.user_agent and self.path_qs:
+        # NB: do not check for self.user_agent, because it can be empty.
+        if self.ip_address and self.path_qs:
             return "%s#%s#%s" % (self.user_agent, self.path_qs, self.ip_address)
         return ''

--- a/server/mlabns/util/resolver.py
+++ b/server/mlabns/util/resolver.py
@@ -96,9 +96,9 @@ class GeoResolver(ResolverBase):
 
         filtered_candidates = []
 
-        prob = client_signature_fetcher.ClientSignatureFetcher().fetch(
-            query.calculate_client_signature())
-        logging.info('prob returned from memcache: %f', prob)
+        sig = query.calculate_client_signature()
+        prob = client_signature_fetcher.ClientSignatureFetcher().fetch(sig)
+        logging.debug('prob returned from memcache for %s: %f', sig, prob)
         if random.uniform(0, 1) > prob:
             # Filter the candidates sites, only keep the '0c' sites
             filtered_candidates = filter(lambda c: c.site_id[-1] == 'c',


### PR DESCRIPTION
This change updates mlab-ns to to support client signatures with empty User-Agents -- this is necessary to block clients in the 6-hour frequency incident. And, this change allows setting a probability of zero for blocking / redirecting clients. This is also necessary for the 6-hour frequency incident.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/179)
<!-- Reviewable:end -->
