### PR TITLE
Read request signatures directly from memcache

### DIFF
--- a/cron.yaml
+++ b/cron.yaml
@@ -18,8 +18,8 @@ cron:
   target: {{TARGET}}
   schedule: every 10 minutes
 
-# Update request signatures in memcache for mlab-ns.
-- description: Update request signatures in memcache for mlab-ns.
-  url: /update_request_signatures
-  target: rate-limiter
-  schedule: every 30 minutes
+## Update request signatures in memcache for mlab-ns.
+#- description: Update request signatures in memcache for mlab-ns.
+#  url: /update_request_signatures
+#  target: rate-limiter
+#  schedule: every 30 minutes

--- a/cron.yaml
+++ b/cron.yaml
@@ -1,25 +1,25 @@
 cron:
-# check for site status, run every minute.
+# Check for site status, run every minute.
 - description: Check sliver tools status
   url: /cron/check_status
   target: {{TARGET}}
   schedule: every 1 minutes
 
-# check for new sites, and for new and/or updated IP addresses, roundrobin information.
+# Check for new sites, and for new and/or updated IP addresses, roundrobin information.
 # run every 24 hours, starting at 06:00
 - description: Check sites, update IP and roundrobin
   url: /cron/check_site
   target: {{TARGET}}
   schedule: every day 06:00
 
-# Update blacklist of client signature list for abusive clients.
-- description: Check client blacklists for abusive clients.
-  url: /cron/update_requests
+# Count client signatures found in memcache.
+- description: Count client signatures found in memcache.
+  url: /cron/count_request_signatures
   target: {{TARGET}}
   schedule: every 10 minutes
 
-# Collect blacklist signatures from mlab-ns.
-- description: Collect blacklist signatures and place them in Datastore.
-  url: /update
+# Update request signatures in memcache for mlab-ns.
+- description: Update request signatures in memcache for mlab-ns.
+  url: /update_request_signatures
   target: rate-limiter
   schedule: every 30 minutes

--- a/server/main.py
+++ b/server/main.py
@@ -13,7 +13,7 @@ app = webapp.WSGIApplication(
     (r'/admin.*', admin.AdminHandler),
     (r'/cron/check_status', update.StatusUpdateHandler),
     (r'/cron/check_site', update.SiteRegistrationHandler),
-    (r'/cron/update_requests', update.BlacklistRequestsHandler),
+    (r'/cron/count_request_signatures', update.CountRequestSignaturesHandler),
     (r'/reload_maxminddb', update.ReloadMaxmindDb),
     (r'/privacy', privacy.PrivacyHandler),
     (r'/docs', docs.DocsHandler),

--- a/server/mlabns/db/client_signature_fetcher.py
+++ b/server/mlabns/db/client_signature_fetcher.py
@@ -32,6 +32,8 @@ class ClientSignatureFetcher(object):
                 # Convert string to a float.
                 return int(probability_str) / 10000.0
             except ValueError as e:
-                logging.warning('Corrupt value in memcache: %s - %s', probability_str, e)
+                logging.warning('Corrupt value in memcache: %s - %s',
+                                probability_str, e)
+
                 # Fall through.
         return 1.0

--- a/server/mlabns/db/client_signature_fetcher.py
+++ b/server/mlabns/db/client_signature_fetcher.py
@@ -1,3 +1,4 @@
+import logging
 from mlabns.util import constants
 
 from google.appengine.api import memcache
@@ -22,9 +23,15 @@ class ClientSignatureFetcher(object):
                  resource will look like
                  '/ndt_ssl?policy=geo_options&format=json...'
         """
-        matched_requests = memcache.get(
+        # NB: records are ints encoded as strings. Ints are fixed-format floats.
+        probability_str = memcache.get(
             key, namespace=constants.MEMCACHE_NAMESPACE_REQUESTS)
         # NB: allow probability to equal zero.
-        if matched_requests is not None:
-            return matched_requests
+        if probability_str is not None:
+            try:
+                # Convert string to a float.
+                return int(probability_str) / 10000.0
+            except ValueError as e:
+                logging.warning('Corrupt value in memcache: %s - %s', probability_str, e)
+                # Fall through.
         return 1.0

--- a/server/mlabns/db/client_signature_fetcher.py
+++ b/server/mlabns/db/client_signature_fetcher.py
@@ -34,6 +34,5 @@ class ClientSignatureFetcher(object):
             except ValueError as e:
                 logging.warning('Corrupt value in memcache: %s - %s',
                                 probability_str, e)
-
                 # Fall through.
         return 1.0

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -530,18 +530,16 @@ class BlacklistRequestsHandler(webapp.RequestHandler):
         found = 0
         missing = 0
         for request in requests:
-            val = memcache.get(
-                request.key().name(),
-                namespace=constants.MEMCACHE_NAMESPACE_REQUESTS)
+            val = memcache.get(request.key().name(),
+                               namespace=constants.MEMCACHE_NAMESPACE_REQUESTS)
             if val is not None:
                 found += 1
             else:
                 missing += 1
 
-        logging.info(
-            ('Client signatures from datastore; '
-            'found_in: %d missing_from: %d memcache'),
-            found, missing)
+        logging.info(('Client signatures from datastore; '
+                      'found_in: %d missing_from: %d memcache'), found, missing)
+
 
 class WarmupHandler(webapp.RequestHandler):
     """Loads expensive queries into memory before starting service."""

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -517,14 +517,11 @@ class ReloadMaxmindDb(webapp.RequestHandler):
         maxmind.get_geo_reader()
 
 
-class BlacklistRequestsHandler(webapp.RequestHandler):
-    """Updates Blacklist Request list."""
+class CountRequestSignaturesHandler(webapp.RequestHandler):
+    """Counts Request Signatures in memcache relative to Datastore."""
 
     def get(self):
-        """Triggers the update handler.
-
-        Load the blacklist information from DataStore and compare to memcache.
-        """
+        """Logs request signature counts found in memcache."""
         namespace_manager.set_namespace('endpoint_stats')
         requests = list(model.Requests.all().fetch(limit=None))
         found = 0

--- a/server/mlabns/util/resolver.py
+++ b/server/mlabns/util/resolver.py
@@ -98,8 +98,10 @@ class GeoResolver(ResolverBase):
 
         sig = query.calculate_client_signature()
         prob = client_signature_fetcher.ClientSignatureFetcher().fetch(sig)
-        logging.debug('prob returned from memcache for %s: %f', sig, prob)
         if random.uniform(0, 1) > prob:
+            # NB: the string format makes log monitoring possible.
+            logging.info(
+                'SIGNATURE_FOUND: %f returned from memcache for %s', prob, sig)
             # Filter the candidates sites, only keep the '0c' sites
             filtered_candidates = filter(lambda c: c.site_id[-1] == 'c',
                                          candidates)

--- a/server/mlabns/util/resolver.py
+++ b/server/mlabns/util/resolver.py
@@ -100,8 +100,8 @@ class GeoResolver(ResolverBase):
         prob = client_signature_fetcher.ClientSignatureFetcher().fetch(sig)
         if random.uniform(0, 1) > prob:
             # NB: the string format makes log monitoring possible.
-            logging.info(
-                'SIGNATURE_FOUND: %f returned from memcache for %s', prob, sig)
+            logging.info('SIGNATURE_FOUND: %f returned from memcache for %s',
+                         prob, sig)
             # Filter the candidates sites, only keep the '0c' sites
             filtered_candidates = filter(lambda c: c.site_id[-1] == 'c',
                                          candidates)


### PR DESCRIPTION
This change is a companion to https://github.com/m-lab/mlab-ns-rate-limit/pull/14

This change reads request signatures from memcache directly without needing to load records from Datatastore periodically. Values are parsed using the memcache convention for formatting probabilities: https://github.com/m-lab/mlab-ns-rate-limit/pull/14/files#diff-04c6e90faac2675aa89e2176d2eec7d8

This change disables the cron job for `/update_request_signatures` handler because this should not run at this time.

This change includes a log line `SIGNATURE_FOUND` that will be suitable calculating for stackdriver or bqx log metrics to monitor rate of client suppression.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/181)
<!-- Reviewable:end -->
