### PR TITLE
Adds new criteria to Prometheus queries for platform cluster disk usage.

### DIFF
--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -35,6 +35,9 @@ QUERIES = {
             script_success{service="ndt_e2e"} OR
             (vdlimit_used{experiment="ndt.iupui"} /
               vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR
+            ((node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"} -
+              node_filesystem_free_bytes{cluster="platform-cluster", mountpoint="/cache/data"}) /
+                node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"}) < bool 0.95 OR
             lame_duck_experiment{experiment="ndt.iupui"} != bool 1 OR
             label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
         )
@@ -45,6 +48,9 @@ QUERIES = {
             script_success{service="ndt_e2e"} OR
             (vdlimit_used{experiment="ndt.iupui"} /
               vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR
+            ((node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"} -
+              node_filesystem_free_bytes{cluster="platform-cluster", mountpoint="/cache/data"}) /
+                node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"}) < bool 0.95 OR
             lame_duck_experiment{experiment="ndt.iupui"} != bool 1 OR
             label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
         )
@@ -55,6 +61,9 @@ QUERIES = {
             script_success{service="ndt_e2e"} OR
             (vdlimit_used{experiment="ndt.iupui"} /
               vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR
+            ((node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"} -
+              node_filesystem_free_bytes{cluster="platform-cluster", mountpoint="/cache/data"}) /
+                node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"}) < bool 0.95 OR
             lame_duck_experiment{experiment="ndt.iupui"} != bool 1 OR
             label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
         )
@@ -65,6 +74,9 @@ QUERIES = {
             script_success{service="ndt_e2e"} OR
             (vdlimit_used{experiment="ndt.iupui"} /
               vdlimit_total{experiment="ndt.iupui"}) < bool 0.95 OR
+            ((node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"} -
+              node_filesystem_free_bytes{cluster="platform-cluster", mountpoint="/cache/data"}) /
+                node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"}) < bool 0.95 OR
             lame_duck_experiment{experiment="ndt.iupui"} != bool 1 OR
             label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
         )


### PR DESCRIPTION
`vdlimit` doesn't exist on the new platform, but node_exporter filesystem metrics do allow us to calculate disk usage. This PR introduces a new disk usage calculation into the mlab-ns Prometheus queries. If the `/cache/data` mount on platform nodes exceeds 95% (similar to `vdlimit`), then the experiment will be flagged as down.

This PR is made possible by m-lab/prometheus-support#430.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/183)
<!-- Reviewable:end -->
