### PR TITLE
Chanes the Prom query for lame-duck on platform nodes to use key instead of value.

### DIFF
--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -38,7 +38,7 @@ QUERIES = {
             ((node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"} -
               node_filesystem_free_bytes{cluster="platform-cluster", mountpoint="/cache/data"}) /
                 node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"}) < bool 0.95 OR
-            kube_node_spec_taint{cluster="platform-cluster", value="lame-duck"} != bool 1 OR
+            kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"} != bool 1 OR
             lame_duck_experiment{experiment="ndt.iupui"} != bool 1 OR
             label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
         )
@@ -52,7 +52,7 @@ QUERIES = {
             ((node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"} -
               node_filesystem_free_bytes{cluster="platform-cluster", mountpoint="/cache/data"}) /
                 node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"}) < bool 0.95 OR
-            kube_node_spec_taint{cluster="platform-cluster", value="lame-duck"} != bool 1 OR
+            kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"} != bool 1 OR
             lame_duck_experiment{experiment="ndt.iupui"} != bool 1 OR
             label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
         )
@@ -66,7 +66,7 @@ QUERIES = {
             ((node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"} -
               node_filesystem_free_bytes{cluster="platform-cluster", mountpoint="/cache/data"}) /
                 node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"}) < bool 0.95 OR
-            kube_node_spec_taint{cluster="platform-cluster", value="lame-duck"} != bool 1 OR
+            kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"} != bool 1 OR
             lame_duck_experiment{experiment="ndt.iupui"} != bool 1 OR
             label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
         )
@@ -80,7 +80,7 @@ QUERIES = {
             ((node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"} -
               node_filesystem_free_bytes{cluster="platform-cluster", mountpoint="/cache/data"}) /
                 node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"}) < bool 0.95 OR
-            kube_node_spec_taint{cluster="platform-cluster", value="lame-duck"} != bool 1 OR
+            kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"} != bool 1 OR
             lame_duck_experiment{experiment="ndt.iupui"} != bool 1 OR
             label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
         )
@@ -88,7 +88,7 @@ QUERIES = {
     'neubot': textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="neubot"} OR
-            kube_node_spec_taint{cluster="platform-cluster", value="lame-duck"} != bool 1 OR
+            kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"} != bool 1 OR
             lame_duck_experiment{experiment="neubot.mlab"} != bool 1 OR
             label_replace(gmx_machine_maintenance, "experiment", "neubot.mlab", "", "") != bool 1
         )
@@ -96,7 +96,7 @@ QUERIES = {
     'neubot_ipv6': textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="neubot_ipv6"} OR
-            kube_node_spec_taint{cluster="platform-cluster", value="lame-duck"} != bool 1 OR
+            kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"} != bool 1 OR
             lame_duck_experiment{experiment="neubot.mlab"} != bool 1 OR
             label_replace(gmx_machine_maintenance, "experiment", "neubot.mlab", "", "") != bool 1
         )
@@ -106,7 +106,7 @@ QUERIES = {
             probe_success{service="mobiperf", instance=~".*:6001"} OR
             probe_success{service="mobiperf", instance=~".*:6002"} OR
             probe_success{service="mobiperf", instance=~".*:6003"} OR
-            kube_node_spec_taint{cluster="platform-cluster", value="lame-duck"} != bool 1 OR
+            kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"} != bool 1 OR
             lame_duck_experiment{experiment="1.michigan"} != bool 1 OR
             label_replace(gmx_machine_maintenance, "experiment", "1.michigan", "", "") != bool 1
         )
@@ -116,7 +116,7 @@ QUERIES = {
             probe_success{service="mobiperf_ipv6", instance=~".*:6001"} OR
             probe_success{service="mobiperf_ipv6", instance=~".*:6002"} OR
             probe_success{service="mobiperf_ipv6", instance=~".*:6003"} OR
-            kube_node_spec_taint{cluster="platform-cluster", value="lame-duck"} != bool 1 OR
+            kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"} != bool 1 OR
             lame_duck_experiment{experiment="1.michigan"} != bool 1 OR
             label_replace(gmx_machine_maintenance, "experiment", "1.michigan", "", "") != bool 1
         )


### PR DESCRIPTION
Using `key` instead of `value` allows the taint to be self-describing, and also allow us to leverage the taint  `value` for some ultra terse description of who/why the node was lame-ducked.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/185)
<!-- Reviewable:end -->
