### PR TITLE
Respond with HTTP 204 when there is no content.

### DIFF
--- a/server/mlabns/handlers/lookup.py
+++ b/server/mlabns/handlers/lookup.py
@@ -48,13 +48,6 @@ class LookupHandler(webapp.RequestHandler):
         For more information about the URL and the supported arguments
         in the query string, see the design doc at http://goo.gl/48S22.
         """
-
-        # TODO: only temporary test.
-        if self.request.path == '/test_204':
-            self.response.headers['Access-Control-Allow-Origin'] = '*'
-            self.response.set_status(204)
-            return
-
         # Check right away whether we should proxy this request.
         url = reverse_proxy.try_reverse_proxy_url(self.request,
                                                   datetime.datetime.now())
@@ -148,9 +141,9 @@ class LookupHandler(webapp.RequestHandler):
             logging.error("Problem: sliver_tools is not a list.")
             return
 
+        # We will respond with HTTP status 204 if len(sliver_tools) == 0
         array_response = False
-        if len(sliver_tools) != 1:
-            # Respond with an array for 0 or more than 1 items.
+        if len(sliver_tools) > 1:
             array_response = True
 
         tool = None
@@ -197,7 +190,10 @@ class LookupHandler(webapp.RequestHandler):
             json_data = "[" + json_data + "]"
         self.response.headers['Access-Control-Allow-Origin'] = '*'
         self.response.headers['Content-Type'] = 'application/json'
-        self.response.out.write(json_data)
+        if json_data:
+            self.response.out.write(json_data)
+        else:
+            self.response.set_status(204)
 
     def send_html_response(self, sliver_tools, query):
         """Sends the response to the lookup request in html format.

--- a/server/mlabns/handlers/lookup.py
+++ b/server/mlabns/handlers/lookup.py
@@ -51,6 +51,7 @@ class LookupHandler(webapp.RequestHandler):
 
         # TODO: only temporary test.
         if self.request.path == '/test_204':
+            self.response.headers['Access-Control-Allow-Origin'] = '*'
             self.response.set_status(204)
             return
 

--- a/server/mlabns/handlers/lookup.py
+++ b/server/mlabns/handlers/lookup.py
@@ -48,6 +48,11 @@ class LookupHandler(webapp.RequestHandler):
         For more information about the URL and the supported arguments
         in the query string, see the design doc at http://goo.gl/48S22.
         """
+
+        # TODO: only temporary test.
+        self.response.set_status(204)
+        return
+
         # Check right away whether we should proxy this request.
         url = reverse_proxy.try_reverse_proxy_url(self.request,
                                                   datetime.datetime.now())

--- a/server/mlabns/handlers/lookup.py
+++ b/server/mlabns/handlers/lookup.py
@@ -50,8 +50,9 @@ class LookupHandler(webapp.RequestHandler):
         """
 
         # TODO: only temporary test.
-        self.response.set_status(204)
-        return
+        if self.request.path == '/test_204':
+            self.response.set_status(204)
+            return
 
         # Check right away whether we should proxy this request.
         url = reverse_proxy.try_reverse_proxy_url(self.request,


### PR DESCRIPTION
This change addresses part of https://github.com/m-lab/mlab-ns/issues/189

Originally, mlab-ns would return status 200 and empty result if there were no servers to report. To implement the first version of the so called "kill switch" (aka "no capacity") signal, we updated mlab-ns to return an empty json list `[]` and status 200.

In hindsight, returning a list type to some clients that request single server results is a mistake. This change instead removes the empty list response in favor of returning status 204 (No Content) when the response is empty. This allows clients to distinguish the content and for mlab-ns to treat list results and single object results more consistently.