### PR TITLE
Migrate mlab-ns to the new siteinfo API

### DIFF
--- a/DESIGN_DOC.md
+++ b/DESIGN_DOC.md
@@ -38,7 +38,7 @@ For a complete snapshot of the current DB see:
 
 mlab-ns detects new sites through a cron job that runs once daily. It causes mlab-ns to query a current site list at the following URL:
 
-* https://storage.googleapis.com/operator-mlab-oti/metadata/v0/current/mlab-site-stats.json
+* https://siteinfo.mlab-oti.measurementlab.net/v1/sites/locations.json
 
 mlab-ns then compares checks if any new sites appear in this list, and if so, registers the new sites in the data store.
 
@@ -48,20 +48,47 @@ mlab-ns is integrated with Prometheus, M-Lab’s monitoring system, to check whi
 
 ## Detecting IP Address Changes
 
-mlab-ns detects changes to M-Lab site IP addresses via a cron job that runs once daily. It fetches the file mlab-host-ips.txt via the following URL:
+mlab-ns detects changes to M-Lab site IP addresses via a cron job that runs once daily. It fetches the file hostnames.json via the following URL:
 
-* https://storage.googleapis.com/operator-mlab-oti/metadata/v0/current/mlab-host-ips.txt
+* https://siteinfo.mlab-oti.measurementlab.net/v1/sites/hostnames.json
 
-The file format is CSV, in the following format:
+The file format is JSON, in the following format:
 
-> [slice FQDN],[IPv4],[IPv6]
+```
+[
+  {
+    "hostname": [slice FQDN],
+	"ipv4": [IPv4],
+	"ipv6": [IPv6]
+  },
+  ...
+]
+```
 
-Where each field is separated by commas. An example of partial results from this file is shown below.
+Where each field is a separate object in the array. An example of partial results from this file is shown below.
 
-    broadband.mpisws.mlab4.sea04.measurement-lab.org,4.71.157.180,
-    bismark.gt.mlab4.sea04.measurement-lab.org,4.71.157.185,
-    utility.mlab.mlab4.sea04.measurement-lab.org,4.71.157.188,2001:1900:2100:16::188
-    ispmon.samknows.mlab4.sea04.measurement-lab.org,4.71.157.184,2001:1900:2100:16::184
+```
+{
+   "hostname": "ndt.iupui.mlab2.ams03.measurement-lab.org",
+   "ipv4": "80.239.169.24",
+   "ipv6": "2001:2030:32::24"
+},
+{
+   "hostname": "geoloc4.uw.mlab2.ams03.measurement-lab.org",
+   "ipv4": "80.239.169.28",
+   "ipv6": "2001:2030:32::28"
+},
+{
+   "hostname": "ispmon.samknows.mlab2.ams03.measurement-lab.org",
+   "ipv4": "80.239.169.30",
+   "ipv6": "2001:2030:32::30"
+},
+{
+   "hostname": "bismark.gt.mlab2.ams03.measurement-lab.org",
+   "ipv4": "80.239.169.31",
+   "ipv6": "2001:2030:32::31"
+},
+```
 
 Using this information, mlab-ns adds sliver information to its data store (for previously unknown slivers) or updates the existing sliver entries in the data store (for previously added slivers).
 

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -175,7 +175,6 @@ class IPUpdateHandler():
 
         Updates sliver tool IP addresses.
         """
-        lines = []
         try:
             project = app_identity.get_application_id()
             if project == 'mlab-ns':
@@ -199,7 +198,7 @@ class IPUpdateHandler():
             rows = json.loads(raw_json)
         except (TypeError, ValueError) as e:
             logging.error('Failed to parse raw json from %s: %s', host_ips_url,
-                e)
+                          e)
             return util.send_not_found(self)
 
         # Fetch all data that we are going to need from the datastore up front.

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -37,8 +37,8 @@ class SiteRegistrationHandler(webapp.RequestHandler):
 
     REQUIRED_FIELDS = [SITE_FIELD, METRO_FIELD, CITY_FIELD, COUNTRY_FIELD,
                        LAT_FIELD, LON_FIELD, ROUNDROBIN_FIELD]
-    DEFAULT_SITE_LIST_URL = 'https://storage.googleapis.com/operator-mlab-oti/metadata/v0/current/mlab-site-stats.json'
-    TEMPLATE_SITE_LIST_URL = 'https://storage.googleapis.com/operator-{project}/metadata/v0/current/mlab-site-stats.json'
+    DEFAULT_SITE_LIST_URL = 'https://siteinfo.mlab-oti.measurementlab.net/v1/sites/locations.json'
+    TEMPLATE_SITE_LIST_URL = 'https://siteinfo.{project}.measurementlab.net/v1/sites/locations.json'
 
     @classmethod
     def _is_valid_site(cls, site):
@@ -167,8 +167,8 @@ class SiteRegistrationHandler(webapp.RequestHandler):
 class IPUpdateHandler():
     """Updates SliverTools' IP addresses."""
 
-    DEFAULT_IP_LIST_URL = 'https://storage.googleapis.com/operator-mlab-oti/metadata/v0/current/mlab-host-ips.txt'
-    TEMPLATE_IP_LIST_URL = 'https://storage.googleapis.com/operator-{project}/metadata/v0/current/mlab-host-ips.txt'
+    DEFAULT_IP_LIST_URL = 'https://siteinfo.mlab-oti.measurementlab.net/v1/sites/hostnames.json'
+    TEMPLATE_IP_LIST_URL = 'https://siteinfo.{project}.measurementlab.net/v1/sites/hostnames.json'
 
     def update(self):
         """Triggers the update handler.
@@ -188,11 +188,18 @@ class IPUpdateHandler():
             return util.send_not_found(self)
 
         try:
-            lines = urllib2.urlopen(host_ips_url).read().strip('\n').split('\n')
-            logging.info('Fetched mlab-host-ips.txt from: %s', host_ips_url)
+            raw_json = urllib2.urlopen(host_ips_url).read()
+            logging.info('Fetched hostnames.json from: %s', host_ips_url)
         except urllib2.HTTPError:
             # TODO(claudiu) Notify(email) when this happens.
             logging.error('Cannot open %s.', host_ips_url)
+            return util.send_not_found(self)
+
+        try:
+            rows = json.loads(raw_json)
+        except (TypeError, ValueError) as e:
+            logging.error('Failed to parse raw json from %s: %s', host_ips_url,
+                e)
             return util.send_not_found(self)
 
         # Fetch all data that we are going to need from the datastore up front.
@@ -200,15 +207,11 @@ class IPUpdateHandler():
         tools = list(model.Tool.all().fetch(limit=None))
         slivertools = list(model.SliverTool.all().fetch(limit=None))
 
-        for line in lines:
-            # Expected format: "FQDN,IPv4,IPv6" (IPv6 can be an empty string).
-            line_fields = line.split(',')
-            if len(line_fields) != 3:
-                logging.error('Line does not have 3 fields: %s.', line)
-                continue
-            fqdn = line_fields[0]
-            ipv4 = line_fields[1]
-            ipv6 = line_fields[2]
+        for row in rows:
+            # Expected keys: "hostname,ipv4,ipv6" (ipv6 can be an empty string).
+            fqdn = row['hostname']
+            ipv4 = row['ipv4']
+            ipv6 = row['ipv6']
 
             if not production_check.is_production_slice(fqdn):
                 continue

--- a/server/mlabns/tests/test_update.py
+++ b/server/mlabns/tests/test_update.py
@@ -43,7 +43,8 @@ class SiteRegistrationHandlerTest(unittest2.TestCase):
         self.addCleanup(util_patch.stop)
         util_patch.start()
 
-    def testGetIgnoresTestSites(self):
+    @mock.patch.object(update.IPUpdateHandler, 'update')
+    def testGetIgnoresTestSites(self, mock_update):
         """Test sites should not be processed in the sites update."""
         urllib2.urlopen.return_value = StringIO.StringIO("""[
 {
@@ -63,11 +64,13 @@ class SiteRegistrationHandlerTest(unittest2.TestCase):
         handler.get()
 
         self.assertTrue(util.send_success.called)
+        self.assertTrue(mock_update.called)
 
         self.assertFalse(model.Site.called,
                          'Test site should not be added to the datastore')
 
-    def testUpdateExistingSites(self):
+    @mock.patch.object(update.IPUpdateHandler, 'update')
+    def testUpdateExistingSites(self, mock_update):
         """Test updating an existing site."""
         urllib2.urlopen.return_value = StringIO.StringIO("""[
 {
@@ -87,9 +90,59 @@ class SiteRegistrationHandlerTest(unittest2.TestCase):
         handler.get()
 
         self.assertTrue(util.send_success.called)
+        self.assertTrue(mock_update.called)
 
         self.assertTrue(model.Site.called,
                         'Update an existing site to the datastore')
+
+
+class IPUpdateHandlerTest(unittest2.TestCase):
+
+    def setUp(self):
+        # Patch out the APIs that IPUpdateHandler calls.
+        get_application_id_patch = mock.patch.object(app_identity,
+                                                     'get_application_id',
+                                                     autospec=True)
+        self.addCleanup(get_application_id_patch.stop)
+        get_application_id_patch.start()
+
+        site_model_patch = mock.patch.object(model, 'Site', autospec=True)
+        self.addCleanup(site_model_patch.stop)
+        site_model_patch.start()
+
+        tool_model_patch = mock.patch.object(model, 'Tool', autospec=True)
+        self.addCleanup(tool_model_patch.stop)
+        tool_model_patch.start()
+
+        sliver_model_patch = mock.patch.object(model, 'SliverTool', autospec=True)
+        self.addCleanup(sliver_model_patch.stop)
+        sliver_model_patch.start()
+
+    @mock.patch.object(urllib2, 'urlopen')
+    @mock.patch.object(update.IPUpdateHandler, 'put_sliver_tool')
+    def test_update(self, mock_put_sliver_tool, mock_urlopen):
+        app_identity.get_application_id.return_value = 'mlab-testing'
+        mock_urlopen.return_value = StringIO.StringIO("""[
+{
+    "hostname": "ndt.iupui.mlab1.xyz01.measurement-lab.org",
+    "ipv4": "192.168.0.1",
+    "ipv6": "2002:AB:1234::1"
+}
+]""")
+        model.Site.all.return_value.fetch.return_value = [
+            mock.Mock(site_id='xyz01')]
+        model.Tool.all.return_value.fetch.return_value = [
+            mock.Mock(
+                slice_id='iupui_ndt', tool_id='ndt')]
+        model.SliverTool.all.return_value.fetch.return_value = [
+            mock.Mock(
+                slice_id='iupui_ndt', tool_id='ndt',
+                fqdn='ndt.iupui.mlab1.xyz0t.measurement-lab.org')]
+
+        handler = update.IPUpdateHandler()
+        handler.update()
+
+        self.assertTrue(mock_put_sliver_tool.called)
 
 
 if __name__ == '__main__':

--- a/server/mlabns/tests/test_update.py
+++ b/server/mlabns/tests/test_update.py
@@ -114,7 +114,9 @@ class IPUpdateHandlerTest(unittest2.TestCase):
         self.addCleanup(tool_model_patch.stop)
         tool_model_patch.start()
 
-        sliver_model_patch = mock.patch.object(model, 'SliverTool', autospec=True)
+        sliver_model_patch = mock.patch.object(model,
+                                               'SliverTool',
+                                               autospec=True)
         self.addCleanup(sliver_model_patch.stop)
         sliver_model_patch.start()
 
@@ -130,14 +132,16 @@ class IPUpdateHandlerTest(unittest2.TestCase):
 }
 ]""")
         model.Site.all.return_value.fetch.return_value = [
-            mock.Mock(site_id='xyz01')]
+            mock.Mock(site_id='xyz01')
+        ]
         model.Tool.all.return_value.fetch.return_value = [
-            mock.Mock(
-                slice_id='iupui_ndt', tool_id='ndt')]
+            mock.Mock(slice_id='iupui_ndt', tool_id='ndt')
+        ]
         model.SliverTool.all.return_value.fetch.return_value = [
-            mock.Mock(
-                slice_id='iupui_ndt', tool_id='ndt',
-                fqdn='ndt.iupui.mlab1.xyz0t.measurement-lab.org')]
+            mock.Mock(slice_id='iupui_ndt',
+                      tool_id='ndt',
+                      fqdn='ndt.iupui.mlab1.xyz0t.measurement-lab.org')
+        ]
 
         handler = update.IPUpdateHandler()
         handler.update()


### PR DESCRIPTION
This change updates the SITE_LIST_URLs & IP_LIST_URLs for the update handlers to read from the siteinfo API. The content of the source files are unchanged.

This change also updates the IP_LIST_URLs from a .txt file to the .json file. Unit tests to exercise the code changes are also included here.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/191)
<!-- Reviewable:end -->
