### PR TITLE
Return no-capacity or not-found when no results found

### DIFF
--- a/server/mlabns/db/model.py
+++ b/server/mlabns/db/model.py
@@ -234,3 +234,8 @@ def get_status_source_deps(source):
     if not tools:
         logging.info('No tools get their status from %s.', source)
     return tools
+
+
+def is_valid_tool(tool_id):
+    """Indicates whether the given tool_id is valid and known in datastore."""
+    return tool_id in get_all_tool_ids()

--- a/server/mlabns/tests/test_lookup.py
+++ b/server/mlabns/tests/test_lookup.py
@@ -7,10 +7,24 @@ from mlabns.handlers import lookup
 from mlabns.util import constants
 from mlabns.util import reverse_proxy
 
+from google.appengine.ext import testbed
+
 
 class LookupTest(unittest2.TestCase):
 
+    def setUp(self):
+        self.testbed = testbed.Testbed()
+        self.testbed.activate()
+        self.testbed.init_datastore_v3_stub()
+        self.testbed.init_memcache_stub()
+
+    def tearDown(self):
+        self.testbed.deactivate()
+
     class OutMockup:
+
+        def __init__(self):
+            self.msg = ''
 
         def write(self, msg):
             self.msg = msg
@@ -29,14 +43,19 @@ class LookupTest(unittest2.TestCase):
 
     class RequestMockup:
 
-        def __init__(self, url='', path=''):
+        def __init__(self, url='', path='', qs=''):
             self.response = mock.Mock()
             self.error_code = None
             self.url = url
             self.scheme = url[:url.index(':')]
             self.path = path
-            self.path_qs = path
+            self.path_qs = path + ('?' + qs if qs else '')
             self.uri = url
+            self.remote_addr = '127.0.0.1'
+            self.headers = {'X-AppEngine-CityLatLong': '30,120',}
+
+        def get(self, key, default_value=''):
+            return getattr(self, key, default_value)
 
         def error(self, error_code):
             self.error_code = error_code
@@ -69,7 +88,7 @@ class LookupTest(unittest2.TestCase):
             'https://new-mlab-ns.appspot.com')
         h = lookup.LookupHandler()
         h.request = LookupTest.RequestMockup(url='https://mlab-ns.appspot.com',
-                                             path='/ndt_ssl')
+                                             path='/ndt_ssl?policy=geo_options')
         h.response = LookupTest.ResponseMockup()
         mock_urlopen.return_value = LookupTest.URLLibResponseMockup(
             'any-fake-data', {'content-type': 'application/json'})
@@ -79,6 +98,49 @@ class LookupTest(unittest2.TestCase):
         # Check response headers, and fake content.
         self.assertEqual(h.response.out.msg, 'any-fake-data')
         self.assertEqual(h.response.headers['Content-Type'], 'application/json')
+
+    @mock.patch.object(reverse_proxy, 'try_reverse_proxy_url')
+    def test_get_with_no_content(self, mock_try_reverse_proxy_url):
+        tool_a = model.Tool(tool_id='tool_a')
+        tool_b = model.Tool(tool_id='tool_b')
+        tool_a.put()
+        tool_b.put()
+        # Skip reverse proxy.
+        mock_try_reverse_proxy_url.return_value = ''
+
+        sliver_a = model.SliverTool(
+            tool_id='tool_a',
+            status='online',
+            site_id='foo01',
+            slice_id='tool_a',
+            fqdn='a.tool.mlab1.foo01.measurement-lab.org',
+            sliver_ipv4='192.168.1.2')
+        sliver_a.put()
+
+        h = lookup.LookupHandler()
+        h.request = LookupTest.RequestMockup(url='https://mlab-ns.appspot.com',
+                                             path='/tool_a',
+                                             qs='policy=geo_options')
+        h.response = LookupTest.ResponseMockup()
+
+        h.get()
+
+        self.assertEqual(h.response.out.msg, '')
+
+    @mock.patch.object(reverse_proxy, 'try_reverse_proxy_url')
+    def test_get_with_not_found(self, mock_try_reverse_proxy_url):
+        # Skip reverse proxy.
+        mock_try_reverse_proxy_url.return_value = ''
+
+        h = lookup.LookupHandler()
+        h.request = LookupTest.RequestMockup(url='https://mlab-ns.appspot.com',
+                                             path='/FAKE_TOOL_ID',
+                                             qs='policy=geo_options')
+        h.response = LookupTest.ResponseMockup()
+
+        h.get()
+
+        self.assertEqual(h.response.out.msg, '{"status_code": "404 Not found"}')
 
     def test_log_location(self):
         h = lookup.LookupHandler()

--- a/server/mlabns/tests/test_lookup.py
+++ b/server/mlabns/tests/test_lookup.py
@@ -126,6 +126,7 @@ class LookupTest(unittest2.TestCase):
         h.get()
 
         self.assertEqual(h.response.out.msg, '')
+        self.assertEqual(h.response.code, 204)
 
     @mock.patch.object(reverse_proxy, 'try_reverse_proxy_url')
     def test_get_with_not_found(self, mock_try_reverse_proxy_url):
@@ -141,6 +142,7 @@ class LookupTest(unittest2.TestCase):
         h.get()
 
         self.assertEqual(h.response.out.msg, '{"status_code": "404 Not found"}')
+        self.assertEqual(h.response.code, 404)
 
     def test_log_location(self):
         h = lookup.LookupHandler()

--- a/server/mlabns/tests/test_model.py
+++ b/server/mlabns/tests/test_model.py
@@ -47,9 +47,12 @@ class GetAllToolIdsTest(unittest2.TestCase):
 
         actual_ids = model.get_all_tool_ids()
         self.assertItemsEqual(actual_ids, expected_ids)
+        self.assertTrue(model.is_valid_tool('tool_c'))
+        self.assertFalse(model.is_valid_tool('this_is_an_invalid_tool_id'))
 
     def test_get_all_tool_ids_no_stored_tools_returns_empty(self):
         self.assertItemsEqual(model.get_all_tool_ids(), [])
+        self.assertFalse(model.is_valid_tool('any_tool_id'))
 
 
 if __name__ == '__main__':

--- a/server/mlabns/tests/test_util.py
+++ b/server/mlabns/tests/test_util.py
@@ -8,6 +8,9 @@ class UtilTestCase(unittest2.TestCase):
 
     class OutMockup:
 
+        def __init__(self):
+            self.msg = ''
+
         def write(self, msg):
             self.msg = msg
 
@@ -17,6 +20,9 @@ class UtilTestCase(unittest2.TestCase):
             self.out = UtilTestCase.OutMockup()
             self.headers = {}
 
+        def set_status(self, code):
+            self.status = code
+
     class RequestMockup:
 
         def __init__(self):
@@ -25,6 +31,14 @@ class UtilTestCase(unittest2.TestCase):
 
         def error(self, error_code):
             self.error_code = error_code
+
+    def testSendNoContent(self):
+        request = UtilTestCase.RequestMockup()
+        util.send_no_content(request)
+        self.assertEqual(request.response.status, 204)
+        self.assertEqual(request.response.headers['Content-Type'],
+                         'application/json')
+        self.assertEqual(request.response.out.msg, '')
 
     def testSendNotFoundJson(self):
         request = UtilTestCase.RequestMockup()

--- a/server/mlabns/util/resolver.py
+++ b/server/mlabns/util/resolver.py
@@ -96,12 +96,12 @@ class GeoResolver(ResolverBase):
 
         filtered_candidates = []
 
-        sig = query.calculate_client_signature()
-        prob = client_signature_fetcher.ClientSignatureFetcher().fetch(sig)
+        prob = client_signature_fetcher.ClientSignatureFetcher().fetch(
+            self.client_signature)
         if random.uniform(0, 1) > prob:
             # NB: the string format makes log monitoring possible.
             logging.info('SIGNATURE_FOUND: %f returned from memcache for %s',
-                         prob, sig)
+                         prob, self.client_signature)
             # Filter the candidates sites, only keep the '0c' sites
             filtered_candidates = filter(lambda c: c.site_id[-1] == 'c',
                                          candidates)
@@ -243,7 +243,7 @@ def new_resolver(policy, client_signature=''):
     elif policy == message.POLICY_COUNTRY:
         return CountryResolver(client_signature)
     elif policy == message.POLICY_GEO_OPTIONS:
-        return GeoResolverWithOptions()
+        return GeoResolverWithOptions(client_signature)
     elif policy == message.POLICY_ALL:
         return AllResolver(client_signature)
     else:

--- a/server/mlabns/util/util.py
+++ b/server/mlabns/util/util.py
@@ -18,6 +18,12 @@ def _get_jinja_template(template_filename):
     return _get_jinja_environment().get_template(template_filename)
 
 
+def send_no_content(request):
+    request.response.headers['Access-Control-Allow-Origin'] = '*'
+    request.response.headers['Content-Type'] = 'application/json'
+    request.response.set_status(204)
+
+
 def send_not_found(request, output_type=message.FORMAT_HTML):
     request.error(404)
     if output_type == message.FORMAT_JSON:


### PR DESCRIPTION
When no results are found for a client query, this could be a result of the client making a bad request (i.e. bad tool_id) or there being no results available for a valid tool_id.

This change adds an additional check before responding to determine if the requested tool_id was valid. If it is valid, then there is "no capacity". If it is invalid, then the request is "not found".

Fixes https://github.com/m-lab/mlab-ns/issues/195

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/196)
<!-- Reviewable:end -->
