### PR TITLE
Support per-experiment ReverseProxyProbability 

### DIFF
--- a/server/mlabns/db/model.py
+++ b/server/mlabns/db/model.py
@@ -1,3 +1,4 @@
+import copy
 import logging
 
 from google.appengine.ext import db
@@ -152,6 +153,11 @@ class ReverseProxyProbability(db.Model):
     name = db.StringProperty()
     probability = db.FloatProperty()
     url = db.StringProperty()
+
+    def with_name(self, name):
+        prob = copy.copy(self)
+        prob.name = name
+        return prob
 
 
 def get_sliver_tool_id(tool_id, slice_id, server_id, site_id):

--- a/server/mlabns/tests/test_reverse_proxy.py
+++ b/server/mlabns/tests/test_reverse_proxy.py
@@ -1,13 +1,8 @@
-import datetime
-import os
-import mock
 import unittest2
 
 from mlabns.db import model
-from mlabns.util import constants
 from mlabns.util import reverse_proxy
 
-from google.appengine.api import memcache
 from google.appengine.ext import testbed
 
 

--- a/server/mlabns/tests/test_reverse_proxy.py
+++ b/server/mlabns/tests/test_reverse_proxy.py
@@ -25,13 +25,12 @@ class ReverseProxyTest(unittest2.TestCase):
 
     def test_get_reverse_proxy_returns_default_value(self):
         # If the entity does not exist, get_reverse_proxy should return a
-        # default probability.
-        actual = reverse_proxy.get_reverse_proxy('default')
+        # default probability of 0.0 for the requested experiment name.
+        actual = reverse_proxy.get_reverse_proxy('not_valid')
 
-        self.assertEqual(actual.name, reverse_proxy.default_reverse_proxy.name)
-        self.assertEqual(actual.probability,
-                         reverse_proxy.default_reverse_proxy.probability)
-        self.assertEqual(actual.url, reverse_proxy.default_reverse_proxy.url)
+        self.assertEqual(actual.name, 'not_valid')
+        self.assertEqual(actual.probability, 0.0)
+        self.assertEqual(actual.url, "https://mlab-ns.appspot.com")
 
     def test_get_reverse_proxy_returns_probability_and_caches(self):
         # If the entity exists, get_reverse_proxy should return it.

--- a/server/mlabns/tests/test_reverse_proxy.py
+++ b/server/mlabns/tests/test_reverse_proxy.py
@@ -27,99 +27,96 @@ class ReverseProxyTest(unittest2.TestCase):
     def tearDown(self):
         self.testbed.deactivate()
 
-    @mock.patch.object(model, 'ReverseProxyProbability')
-    def test_get_reverse_proxy_returns_mock_value(self, mock_reverse_proxy):
-        mock_reverse_proxy.return_value.all.return_value.run.return_value = (
-            [self.fake_reverse_proxy])
+    # @mock.patch.object(model, 'ReverseProxyProbability')
+    # def test_get_reverse_proxy_returns_mock_value(self, mock_reverse_proxy):
+    #     mock_reverse_proxy.return_value.get_by_key_name.return_value = self.fake_reverse_proxy
+    #     actual = reverse_proxy.get_reverse_proxy('default')
 
-        actual = reverse_proxy.get_reverse_proxy()
+    #     self.assertEqual(actual.name, self.fake_reverse_proxy.name)
+    #     self.assertEqual(actual.probability,
+    #                      self.fake_reverse_proxy.probability)
+    #     self.assertEqual(actual.url, self.fake_reverse_proxy.url)
 
-        self.assertEqual(actual.name, self.fake_reverse_proxy.name)
-        self.assertEqual(actual.probability,
-                         self.fake_reverse_proxy.probability)
-        self.assertEqual(actual.url, self.fake_reverse_proxy.url)
+    # @mock.patch.object(model, 'ReverseProxyProbability')
+    # def test_get_reverse_proxy_returns_default_value(self, mock_reverse_proxy):
+    #     mock_reverse_proxy.return_value.get_by_key_name.return_value = None
+    #     actual = reverse_proxy.get_reverse_proxy('default')
 
-    @mock.patch.object(model, 'ReverseProxyProbability')
-    def test_get_reverse_proxy_returns_default_value(self, mock_reverse_proxy):
-        mock_reverse_proxy.return_value.all.return_value.run.return_value = []
+    #     self.assertEqual(actual, reverse_proxy.default_reverse_proxy)
+    #     self.assertEqual(actual.name, reverse_proxy.default_reverse_proxy.name)
+    #     self.assertEqual(actual.probability,
+    #                      reverse_proxy.default_reverse_proxy.probability)
+    #     self.assertEqual(actual.url, reverse_proxy.default_reverse_proxy.url)
 
-        actual = reverse_proxy.get_reverse_proxy()
+    # def test_during_business_hours_returns_true(self):
+    #     t = datetime.datetime(2019, 1, 24, 16, 0, 0)
+    #     self.assertTrue(reverse_proxy.during_business_hours(t))
 
-        self.assertEqual(actual, reverse_proxy.default_reverse_proxy)
-        self.assertEqual(actual.name, reverse_proxy.default_reverse_proxy.name)
-        self.assertEqual(actual.probability,
-                         reverse_proxy.default_reverse_proxy.probability)
-        self.assertEqual(actual.url, reverse_proxy.default_reverse_proxy.url)
+    # def test_during_business_hours_with_ignore_environment_returns_true(self):
+    #     t = datetime.datetime(2019, 1, 25, 16, 0, 0)
+    #     os.environ['IGNORE_BUSINESS_HOURS'] = '1'
+    #     self.assertTrue(reverse_proxy.during_business_hours(t))
+    #     del os.environ['IGNORE_BUSINESS_HOURS']
 
-    def test_during_business_hours_returns_true(self):
-        t = datetime.datetime(2019, 1, 24, 16, 0, 0)
-        self.assertTrue(reverse_proxy.during_business_hours(t))
+    # def test_during_business_hours_returns_false(self):
+    #     t = datetime.datetime(2019, 1, 25, 16, 0, 0)
+    #     self.assertFalse(reverse_proxy.during_business_hours(t))
 
-    def test_during_business_hours_with_ignore_environment_returns_true(self):
-        t = datetime.datetime(2019, 1, 25, 16, 0, 0)
-        os.environ['IGNORE_BUSINESS_HOURS'] = '1'
-        self.assertTrue(reverse_proxy.during_business_hours(t))
-        del os.environ['IGNORE_BUSINESS_HOURS']
+    # def test_try_reverse_proxy_url_when_wrong_path_returns_emptystr(self):
+    #     mock_request = mock.Mock()
+    #     mock_request.path = '/wrong_path'
+    #     t = datetime.datetime(2019, 1, 24, 16, 0, 0)
 
-    def test_during_business_hours_returns_false(self):
-        t = datetime.datetime(2019, 1, 25, 16, 0, 0)
-        self.assertFalse(reverse_proxy.during_business_hours(t))
+    #     url = reverse_proxy.try_reverse_proxy_url(mock_request, t)
 
-    def test_try_reverse_proxy_url_when_wrong_path_returns_emptystr(self):
-        mock_request = mock.Mock()
-        mock_request.path = '/wrong_path'
-        t = datetime.datetime(2019, 1, 24, 16, 0, 0)
+    #     self.assertEqual(url, "")
 
-        url = reverse_proxy.try_reverse_proxy_url(mock_request, t)
+    # def test_try_reverse_proxy_url_when_probability_zero_returns_emptystr(self):
+    #     mock_request = mock.Mock()
+    #     mock_request.path = '/ndt_ssl'
+    #     t = datetime.datetime(2019, 1, 24, 16, 0, 0)
+    #     rp = model.ReverseProxyProbability(name="default",
+    #                                        probability=0.0,
+    #                                        url="https://fake.appspot.com")
+    #     memcache.set('default',
+    #                  rp,
+    #                  time=1800,
+    #                  namespace=constants.MEMCACHE_NAMESPACE_REVERSE_PROXY)
 
-        self.assertEqual(url, "")
+    #     url = reverse_proxy.try_reverse_proxy_url(mock_request, t)
 
-    def test_try_reverse_proxy_url_when_probability_zero_returns_emptystr(self):
-        mock_request = mock.Mock()
-        mock_request.path = '/ndt_ssl'
-        t = datetime.datetime(2019, 1, 24, 16, 0, 0)
-        rp = model.ReverseProxyProbability(name="default",
-                                           probability=0.0,
-                                           url="https://fake.appspot.com")
-        memcache.set('default',
-                     rp,
-                     time=1800,
-                     namespace=constants.MEMCACHE_NAMESPACE_REVERSE_PROXY)
+    #     self.assertEqual(url, "")
 
-        url = reverse_proxy.try_reverse_proxy_url(mock_request, t)
+    # def test_try_reverse_proxy_url_when_outside_business_returns_emptystr(self):
+    #     mock_request = mock.Mock()
+    #     mock_request.path = '/ndt_ssl'
+    #     t = datetime.datetime(2019, 1, 25, 16, 0, 0)
+    #     rp = model.ReverseProxyProbability(name="default",
+    #                                        probability=1.0,
+    #                                        url="https://fake.appspot.com")
+    #     memcache.set('default',
+    #                  rp,
+    #                  time=1800,
+    #                  namespace=constants.MEMCACHE_NAMESPACE_REVERSE_PROXY)
 
-        self.assertEqual(url, "")
+    #     url = reverse_proxy.try_reverse_proxy_url(mock_request, t)
 
-    def test_try_reverse_proxy_url_when_outside_business_returns_emptystr(self):
-        mock_request = mock.Mock()
-        mock_request.path = '/ndt_ssl'
-        t = datetime.datetime(2019, 1, 25, 16, 0, 0)
-        rp = model.ReverseProxyProbability(name="default",
-                                           probability=1.0,
-                                           url="https://fake.appspot.com")
-        memcache.set('default',
-                     rp,
-                     time=1800,
-                     namespace=constants.MEMCACHE_NAMESPACE_REVERSE_PROXY)
+    #     self.assertEqual(url, "")
 
-        url = reverse_proxy.try_reverse_proxy_url(mock_request, t)
+    # def test_try_reverse_proxy_url_returns_url(self):
+    #     mock_request = mock.Mock()
+    #     mock_request.path = '/ndt_ssl'
+    #     mock_request.path_qs = '/ndt_ssl?format=geo_options'
+    #     t = datetime.datetime(2019, 1, 24, 16, 0, 0)
+    #     rp = model.ReverseProxyProbability(name="default",
+    #                                        probability=1.0,
+    #                                        url="https://fake.appspot.com")
+    #     memcache.set('default',
+    #                  rp,
+    #                  time=1800,
+    #                  namespace=constants.MEMCACHE_NAMESPACE_REVERSE_PROXY)
 
-        self.assertEqual(url, "")
+    #     actual_url = reverse_proxy.try_reverse_proxy_url(mock_request, t)
 
-    def test_try_reverse_proxy_url_returns_url(self):
-        mock_request = mock.Mock()
-        mock_request.path = '/ndt_ssl'
-        mock_request.path_qs = '/ndt_ssl?format=geo_options'
-        t = datetime.datetime(2019, 1, 24, 16, 0, 0)
-        rp = model.ReverseProxyProbability(name="default",
-                                           probability=1.0,
-                                           url="https://fake.appspot.com")
-        memcache.set('default',
-                     rp,
-                     time=1800,
-                     namespace=constants.MEMCACHE_NAMESPACE_REVERSE_PROXY)
-
-        actual_url = reverse_proxy.try_reverse_proxy_url(mock_request, t)
-
-        self.assertEqual(actual_url,
-                         'https://fake.appspot.com/ndt_ssl?format=geo_options')
+    #     self.assertEqual(actual_url,
+    #                      'https://fake.appspot.com/ndt_ssl?format=geo_options')

--- a/server/mlabns/tests/test_reverse_proxy.py
+++ b/server/mlabns/tests/test_reverse_proxy.py
@@ -45,6 +45,7 @@ class ReverseProxyTest(unittest2.TestCase):
             url="https://fake.appspot.com")
         ndt7_probability.put()
         ndt_ssl_probability.put()
+
         actual = reverse_proxy.get_reverse_proxy('ndt_ssl')
 
         self.assertEqual(actual.name, ndt_ssl_probability.name)

--- a/server/mlabns/tests/test_reverse_proxy.py
+++ b/server/mlabns/tests/test_reverse_proxy.py
@@ -1,8 +1,13 @@
+import datetime
+import os
+import mock
 import unittest2
 
 from mlabns.db import model
+from mlabns.util import constants
 from mlabns.util import reverse_proxy
 
+from google.appengine.api import memcache
 from google.appengine.ext import testbed
 
 
@@ -13,106 +18,131 @@ class ReverseProxyTest(unittest2.TestCase):
         self.testbed.activate()
         self.testbed.init_all_stubs()
 
-        self.fake_reverse_proxy = model.ReverseProxyProbability(
-            name="default",
-            probability=0.0,
-            url="https://mlab-ns.appspot.com")
         reverse_proxy._reverse_proxy = None
 
     def tearDown(self):
         self.testbed.deactivate()
 
-    @mock.patch.object(model, 'ReverseProxyProbability')
-    def test_get_reverse_proxy_returns_mock_value(self, mock_reverse_proxy):
-        mock_reverse_proxy.return_value.all.return_value.run.return_value = (
-            [self.fake_reverse_proxy])
+    def test_get_reverse_proxy_returns_default_value(self):
+        # If the entity does not exist, get_reverse_proxy should return a
+        # default probability.
         actual = reverse_proxy.get_reverse_proxy('default')
 
-        self.assertEqual(actual.name, self.fake_reverse_proxy.name)
+        self.assertEqual(actual.name, reverse_proxy.default_reverse_proxy.name)
         self.assertEqual(actual.probability,
-                          self.fake_reverse_proxy.probability)
-        self.assertEqual(actual.url, self.fake_reverse_proxy.url)
+                         reverse_proxy.default_reverse_proxy.probability)
+        self.assertEqual(actual.url, reverse_proxy.default_reverse_proxy.url)
 
-    # @mock.patch.object(model, 'ReverseProxyProbability')
-    # def test_get_reverse_proxy_returns_default_value(self, mock_reverse_proxy):
-    #     mock_reverse_proxy.return_value.get_by_key_name.return_value = None
-    #     actual = reverse_proxy.get_reverse_proxy('default')
+    def test_get_reverse_proxy_returns_probability_and_caches(self):
+        # If the entity exists, get_reverse_proxy should return it.
+        ndt7_probability = model.ReverseProxyProbability(
+            name="ndt7",
+            probability=1.0,
+            url="https://fake.appspot.com")
+        ndt_ssl_probability = model.ReverseProxyProbability(
+            name="ndt_ssl",
+            probability=1.0,
+            url="https://fake.appspot.com")
+        ndt7_probability.put()
+        ndt_ssl_probability.put()
+        actual = reverse_proxy.get_reverse_proxy('ndt_ssl')
 
-    #     self.assertEqual(actual, reverse_proxy.default_reverse_proxy)
-    #     self.assertEqual(actual.name, reverse_proxy.default_reverse_proxy.name)
-    #     self.assertEqual(actual.probability,
-    #                      reverse_proxy.default_reverse_proxy.probability)
-    #     self.assertEqual(actual.url, reverse_proxy.default_reverse_proxy.url)
+        self.assertEqual(actual.name, ndt_ssl_probability.name)
+        self.assertEqual(actual.probability, ndt_ssl_probability.probability)
+        self.assertEqual(actual.url, ndt_ssl_probability.url)
 
-    # def test_during_business_hours_returns_true(self):
-    #     t = datetime.datetime(2019, 1, 24, 16, 0, 0)
-    #     self.assertTrue(reverse_proxy.during_business_hours(t))
+    def test_get_reverse_proxy_caches_entities(self):
+        # get_reverse_proxy should refresh memcache at each cache miss.
+        ndt7_probability = model.ReverseProxyProbability(
+            name="ndt7",
+            probability=1.0,
+            url="https://fake.appspot.com")
+        ndt_ssl_probability = model.ReverseProxyProbability(
+            name="ndt_ssl",
+            probability=1.0,
+            url="https://fake.appspot.com")
+        ndt7_probability.put()
+        ndt_ssl_probability.put()
 
-    # def test_during_business_hours_with_ignore_environment_returns_true(self):
-    #     t = datetime.datetime(2019, 1, 25, 16, 0, 0)
-    #     os.environ['IGNORE_BUSINESS_HOURS'] = '1'
-    #     self.assertTrue(reverse_proxy.during_business_hours(t))
-    #     del os.environ['IGNORE_BUSINESS_HOURS']
+        reverse_proxy.get_reverse_proxy("ndt_ssl")
 
-    # def test_during_business_hours_returns_false(self):
-    #     t = datetime.datetime(2019, 1, 25, 16, 0, 0)
-    #     self.assertFalse(reverse_proxy.during_business_hours(t))
+        cached_ndt = memcache.get(
+            "ndt_ssl",
+            namespace=constants.MEMCACHE_NAMESPACE_REVERSE_PROXY)
+        cached_ndt7 = memcache.get(
+            "ndt7", namespace=constants.MEMCACHE_NAMESPACE_REVERSE_PROXY)
+        self.assertEqual(cached_ndt.name, ndt_ssl_probability.name)
+        self.assertEqual(cached_ndt.probability,
+                         ndt_ssl_probability.probability)
+        self.assertEqual(cached_ndt.url, ndt_ssl_probability.url)
 
-    # def test_try_reverse_proxy_url_when_wrong_path_returns_emptystr(self):
-    #     mock_request = mock.Mock()
-    #     mock_request.path = '/wrong_path'
-    #     t = datetime.datetime(2019, 1, 24, 16, 0, 0)
+        self.assertEqual(cached_ndt7.name, ndt7_probability.name)
+        self.assertEqual(cached_ndt7.probability, ndt7_probability.probability)
+        self.assertEqual(cached_ndt7.url, ndt7_probability.url)
 
-    #     url = reverse_proxy.try_reverse_proxy_url(mock_request, t)
+    def test_during_business_hours_returns_true(self):
+        t = datetime.datetime(2019, 1, 24, 16, 0, 0)
+        self.assertTrue(reverse_proxy.during_business_hours(t))
 
-    #     self.assertEqual(url, "")
+    def test_during_business_hours_with_ignore_environment_returns_true(self):
+        t = datetime.datetime(2019, 1, 25, 16, 0, 0)
+        os.environ['IGNORE_BUSINESS_HOURS'] = '1'
+        self.assertTrue(reverse_proxy.during_business_hours(t))
+        del os.environ['IGNORE_BUSINESS_HOURS']
 
-    # def test_try_reverse_proxy_url_when_probability_zero_returns_emptystr(self):
-    #     mock_request = mock.Mock()
-    #     mock_request.path = '/ndt_ssl'
-    #     t = datetime.datetime(2019, 1, 24, 16, 0, 0)
-    #     rp = model.ReverseProxyProbability(name="default",
-    #                                        probability=0.0,
-    #                                        url="https://fake.appspot.com")
-    #     memcache.set('default',
-    #                  rp,
-    #                  time=1800,
-    #                  namespace=constants.MEMCACHE_NAMESPACE_REVERSE_PROXY)
+    def test_during_business_hours_returns_false(self):
+        t = datetime.datetime(2019, 1, 25, 16, 0, 0)
+        self.assertFalse(reverse_proxy.during_business_hours(t))
 
-    #     url = reverse_proxy.try_reverse_proxy_url(mock_request, t)
+    def test_try_reverse_proxy_url_when_wrong_path_returns_emptystr(self):
+        mock_request = mock.Mock()
+        mock_request.path = '/wrong_path'
+        t = datetime.datetime(2019, 1, 24, 16, 0, 0)
 
-    #     self.assertEqual(url, "")
+        url = reverse_proxy.try_reverse_proxy_url(mock_request, t)
 
-    # def test_try_reverse_proxy_url_when_outside_business_returns_emptystr(self):
-    #     mock_request = mock.Mock()
-    #     mock_request.path = '/ndt_ssl'
-    #     t = datetime.datetime(2019, 1, 25, 16, 0, 0)
-    #     rp = model.ReverseProxyProbability(name="default",
-    #                                        probability=1.0,
-    #                                        url="https://fake.appspot.com")
-    #     memcache.set('default',
-    #                  rp,
-    #                  time=1800,
-    #                  namespace=constants.MEMCACHE_NAMESPACE_REVERSE_PROXY)
+        self.assertEqual(url, "")
 
-    #     url = reverse_proxy.try_reverse_proxy_url(mock_request, t)
+    def test_try_reverse_proxy_url_when_probability_zero_returns_emptystr(self):
+        ndt_zero_probability = model.ReverseProxyProbability(
+            name="ndt_ssl",
+            probability=0.0,
+            url="https://fake.appspot.com")
+        ndt_zero_probability.put()
+        mock_request = mock.Mock()
+        mock_request.path = '/ndt_ssl'
+        t = datetime.datetime(2019, 1, 24, 16, 0, 0)
 
-    #     self.assertEqual(url, "")
+        url = reverse_proxy.try_reverse_proxy_url(mock_request, t)
 
-    # def test_try_reverse_proxy_url_returns_url(self):
-    #     mock_request = mock.Mock()
-    #     mock_request.path = '/ndt_ssl'
-    #     mock_request.path_qs = '/ndt_ssl?format=geo_options'
-    #     t = datetime.datetime(2019, 1, 24, 16, 0, 0)
-    #     rp = model.ReverseProxyProbability(name="default",
-    #                                        probability=1.0,
-    #                                        url="https://fake.appspot.com")
-    #     memcache.set('default',
-    #                  rp,
-    #                  time=1800,
-    #                  namespace=constants.MEMCACHE_NAMESPACE_REVERSE_PROXY)
+        self.assertEqual(url, "")
 
-    #     actual_url = reverse_proxy.try_reverse_proxy_url(mock_request, t)
+    def test_try_reverse_proxy_url_when_outside_business_returns_emptystr(self):
+        ndt_ssl_probability = model.ReverseProxyProbability(
+            name="ndt_ssl",
+            probability=1.0,
+            url="https://fake.appspot.com")
+        ndt_ssl_probability.put()
+        mock_request = mock.Mock()
+        mock_request.path = '/ndt_ssl'
+        t = datetime.datetime(2019, 1, 25, 16, 0, 0)
 
-    #     self.assertEqual(actual_url,
-    #                      'https://fake.appspot.com/ndt_ssl?format=geo_options')
+        url = reverse_proxy.try_reverse_proxy_url(mock_request, t)
+
+        self.assertEqual(url, "")
+
+    def test_try_reverse_proxy_url_returns_url(self):
+        ndt_ssl_probability = model.ReverseProxyProbability(
+            name="ndt_ssl",
+            probability=1.0,
+            url="https://fake.appspot.com")
+        ndt_ssl_probability.put()
+        mock_request = mock.Mock()
+        mock_request.path = '/ndt_ssl'
+        mock_request.path_qs = '/ndt_ssl?format=geo_options'
+        t = datetime.datetime(2019, 1, 24, 16, 0, 0)
+
+        actual_url = reverse_proxy.try_reverse_proxy_url(mock_request, t)
+
+        self.assertEqual(actual_url,
+                         'https://fake.appspot.com/ndt_ssl?format=geo_options')

--- a/server/mlabns/tests/test_reverse_proxy.py
+++ b/server/mlabns/tests/test_reverse_proxy.py
@@ -22,15 +22,16 @@ class ReverseProxyTest(unittest2.TestCase):
     def tearDown(self):
         self.testbed.deactivate()
 
-    # @mock.patch.object(model, 'ReverseProxyProbability')
-    # def test_get_reverse_proxy_returns_mock_value(self, mock_reverse_proxy):
-    #     mock_reverse_proxy.return_value.get_by_key_name.return_value = self.fake_reverse_proxy
-    #     actual = reverse_proxy.get_reverse_proxy('default')
+    @mock.patch.object(model, 'ReverseProxyProbability')
+    def test_get_reverse_proxy_returns_mock_value(self, mock_reverse_proxy):
+        mock_reverse_proxy.return_value.all.return_value.run.return_value = (
+            [self.fake_reverse_proxy])
+        actual = reverse_proxy.get_reverse_proxy('default')
 
-    #     self.assertEqual(actual.name, self.fake_reverse_proxy.name)
-    #     self.assertEqual(actual.probability,
-    #                      self.fake_reverse_proxy.probability)
-    #     self.assertEqual(actual.url, self.fake_reverse_proxy.url)
+        self.assertEqual(actual.name, self.fake_reverse_proxy.name)
+        self.assertEqual(actual.probability,
+                          self.fake_reverse_proxy.probability)
+        self.assertEqual(actual.url, self.fake_reverse_proxy.url)
 
     # @mock.patch.object(model, 'ReverseProxyProbability')
     # def test_get_reverse_proxy_returns_default_value(self, mock_reverse_proxy):

--- a/server/mlabns/util/reverse_proxy.py
+++ b/server/mlabns/util/reverse_proxy.py
@@ -15,8 +15,7 @@ default_reverse_proxy = model.ReverseProxyProbability(
 
 
 def get_reverse_proxy(experiment):
-    """Reads and caches the ReverseProxyProbability record for a given experiment.
-    If the experiment does not exist, it returns a default probability."""
+    """Reads and caches the ReverseProxyProbability record for an experiment"""
     reverse_proxy = memcache.get(
         experiment,
         namespace=constants.MEMCACHE_NAMESPACE_REVERSE_PROXY)

--- a/server/mlabns/util/reverse_proxy.py
+++ b/server/mlabns/util/reverse_proxy.py
@@ -27,7 +27,7 @@ def get_reverse_proxy(experiment):
         # Update ReverseProxyProbability for all the experiments.
         for prob in model.ReverseProxyProbability.all().run():
             if experiment == prob.name:
-                reverse_proxy = experiment
+                reverse_proxy = prob
 
             if not memcache.set(
                     prob.name,
@@ -37,10 +37,6 @@ def get_reverse_proxy(experiment):
                 logging.error(
                     'Failed to update ReverseProxyProbability in memcache ' +
                     'for experiment %s', prob.name)
-
-        reverse_proxy = memcache.get(
-            experiment,
-            namespace=constants.MEMCACHE_NAMESPACE_REVERSE_PROXY)
 
         if reverse_proxy is None:
             logging.info('No reverse proxy probability found; using default')

--- a/server/mlabns/util/reverse_proxy.py
+++ b/server/mlabns/util/reverse_proxy.py
@@ -10,7 +10,7 @@ from mlabns.util import constants
 # Default value if datastore contains no records.
 default_reverse_proxy = model.ReverseProxyProbability(
     name="default",
-    probability=1.0,
+    probability=0.0,
     url="https://mlab-ns.appspot.com")
 
 
@@ -40,7 +40,7 @@ def get_reverse_proxy(experiment):
 
         if reverse_proxy is None:
             logging.info('No reverse proxy probability found; using default')
-            reverse_proxy = default_reverse_proxy
+            reverse_proxy = default_reverse_proxy.with_name(experiment)
 
     return reverse_proxy
 

--- a/server/mlabns/util/reverse_proxy.py
+++ b/server/mlabns/util/reverse_proxy.py
@@ -21,17 +21,18 @@ def get_reverse_proxy(experiment):
         experiment,
         namespace=constants.MEMCACHE_NAMESPACE_REVERSE_PROXY)
     if reverse_proxy is None:
-        reverse_proxy = model.ReverseProxyProbability.get_by_key_name(experiment)
+        reverse_proxy = model.ReverseProxyProbability.get_by_key_name(
+            experiment)
 
         if reverse_proxy is None:
             logging.info('No reverse proxy probability found; using default')
             return default_reverse_proxy
 
         if not memcache.set(
-            experiment,
-            reverse_proxy,
-            time=1800,
-            namespace=constants.MEMCACHE_NAMESPACE_REVERSE_PROXY):
+                experiment,
+                reverse_proxy,
+                time=1800,
+                namespace=constants.MEMCACHE_NAMESPACE_REVERSE_PROXY):
 
             logging.error(
                 'Failed to update ReverseProxyProbability in memcache')

--- a/server/mlabns/util/reverse_proxy.py
+++ b/server/mlabns/util/reverse_proxy.py
@@ -7,7 +7,7 @@ from google.appengine.api import memcache
 from mlabns.db import model
 from mlabns.util import constants
 
-# Default value if datastore contains no records for a given experiment.
+# Default value if datastore contains no record for a given experiment.
 # This object should not be returned directly, but you can make a copy
 # with a custom name by calling default_reverse_proxy.with_name("name").
 default_reverse_proxy = model.ReverseProxyProbability(

--- a/server/mlabns/util/reverse_proxy.py
+++ b/server/mlabns/util/reverse_proxy.py
@@ -20,6 +20,8 @@ def get_reverse_proxy(experiment):
         experiment,
         namespace=constants.MEMCACHE_NAMESPACE_REVERSE_PROXY)
     if reverse_proxy is None:
+        logging.info("Getting reverse proxy probability for experiment" +
+                     experiment)
         reverse_proxy = model.ReverseProxyProbability.get_by_key_name(
             experiment)
 

--- a/server/mlabns/util/reverse_proxy.py
+++ b/server/mlabns/util/reverse_proxy.py
@@ -10,7 +10,7 @@ from mlabns.util import constants
 # Default value if datastore contains no records.
 default_reverse_proxy = model.ReverseProxyProbability(
     name="default",
-    probability=0.0,
+    probability=1.0,
     url="https://mlab-ns.appspot.com")
 
 

--- a/server/mlabns/util/reverse_proxy.py
+++ b/server/mlabns/util/reverse_proxy.py
@@ -15,7 +15,10 @@ default_reverse_proxy = model.ReverseProxyProbability(
 
 
 def get_reverse_proxy(experiment):
-    """Reads and caches the ReverseProxyProbability record for an experiment"""
+    """Reads the ReverseProxyProbability record for an experiment.
+
+    If the entity is not cached, it also refreshes the cache.
+    """
     reverse_proxy = memcache.get(
         experiment,
         namespace=constants.MEMCACHE_NAMESPACE_REVERSE_PROXY)
@@ -23,6 +26,9 @@ def get_reverse_proxy(experiment):
     if reverse_proxy is None:
         # Update ReverseProxyProbability for all the experiments.
         for prob in model.ReverseProxyProbability.all().run():
+            if experiment == prob.name:
+                reverse_proxy = experiment
+
             if not memcache.set(
                     prob.name,
                     prob,

--- a/server/mlabns/util/reverse_proxy.py
+++ b/server/mlabns/util/reverse_proxy.py
@@ -7,7 +7,9 @@ from google.appengine.api import memcache
 from mlabns.db import model
 from mlabns.util import constants
 
-# Default value if datastore contains no records.
+# Default value if datastore contains no records for a given experiment.
+# This object should not be returned directly, but you can make a copy
+# with a custom name by calling default_reverse_proxy.with_name("name").
 default_reverse_proxy = model.ReverseProxyProbability(
     name="default",
     probability=0.0,


### PR DESCRIPTION
This PR allows to define different probabilities and redirect urls for different experiments in datastore.

Also, it changes the tests to use the emulated Datastore and memcache instead of mocking calls.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/199)
<!-- Reviewable:end -->
