### PR TITLE
Forward latitude & longitude from client on reverse proxy requests

### DIFF
--- a/server/mlabns/handlers/lookup.py
+++ b/server/mlabns/handlers/lookup.py
@@ -48,8 +48,11 @@ class LookupHandler(webapp.RequestHandler):
         For more information about the URL and the supported arguments
         in the query string, see the design doc at http://goo.gl/48S22.
         """
+        query = lookup_query.LookupQuery()
+        query.initialize_from_http_request(self.request)
+
         # Check right away whether we should proxy this request.
-        url = reverse_proxy.try_reverse_proxy_url(self.request,
+        url = reverse_proxy.try_reverse_proxy_url(query,
                                                   datetime.datetime.now())
         if url:
             # NB: if sending the proxy url is unsuccessful, then fall through to
@@ -58,9 +61,6 @@ class LookupHandler(webapp.RequestHandler):
             if success:
                 logging.info('[reverse_proxy],true,%s', url)
                 return
-
-        query = lookup_query.LookupQuery()
-        query.initialize_from_http_request(self.request)
 
         logging.info('Policy is %s', query.policy)
 

--- a/server/mlabns/tests/test_reverse_proxy.py
+++ b/server/mlabns/tests/test_reverse_proxy.py
@@ -131,7 +131,7 @@ class ReverseProxyTest(unittest2.TestCase):
 
         self.assertEqual(url, "")
 
-    def test_try_reverse_proxy_url_returns_url(self):
+    def test_try_reverse_proxy_url_returns_url_with_latlon(self):
         ndt_ssl_probability = model.ReverseProxyProbability(
             name="ndt_ssl",
             probability=1.0,
@@ -140,9 +140,31 @@ class ReverseProxyTest(unittest2.TestCase):
         mock_request = mock.Mock()
         mock_request.path = '/ndt_ssl'
         mock_request.path_qs = '/ndt_ssl?format=geo_options'
+        mock_request.latitude = 40.7
+        mock_request.longitude = 74.0
         t = datetime.datetime(2019, 1, 24, 16, 0, 0)
 
         actual_url = reverse_proxy.try_reverse_proxy_url(mock_request, t)
 
-        self.assertEqual(actual_url,
-                         'https://fake.appspot.com/ndt_ssl?format=geo_options')
+        self.assertEqual(actual_url, (
+            'https://fake.appspot.com/ndt_ssl?format=geo_options&lat=40.700000'
+            '&lon=74.000000'))
+
+    def test_try_reverse_proxy_url_returns_url_with_only_latlon(self):
+        ndt_ssl_probability = model.ReverseProxyProbability(
+            name="ndt_ssl",
+            probability=1.0,
+            url="https://fake.appspot.com")
+        ndt_ssl_probability.put()
+        mock_request = mock.Mock()
+        mock_request.path = '/ndt_ssl'
+        mock_request.path_qs = '/ndt_ssl'
+        mock_request.latitude = 40.7
+        mock_request.longitude = 74.0
+        t = datetime.datetime(2019, 1, 24, 16, 0, 0)
+
+        actual_url = reverse_proxy.try_reverse_proxy_url(mock_request, t)
+
+        self.assertEqual(
+            actual_url,
+            'https://fake.appspot.com/ndt_ssl?lat=40.700000&lon=74.000000')

--- a/server/mlabns/util/lookup_query.py
+++ b/server/mlabns/util/lookup_query.py
@@ -78,6 +78,7 @@ class LookupQuery:
             request: An instance of google.appengine.webapp.Request.
         """
         self.tool_id = request.path.strip('/').split('/')[0]
+        self.path = request.path
         self._set_response_format(request)
         self._set_ip_address(request)
         self._set_tool_address_family(request)


### PR DESCRIPTION
When changing Redirect to ReverseProxy -- I neglected to consider how client location would be loaded by the proxied server.

This change adds support for loading and forwarding the client latitude and longitude to the proxy server. With this change, the forwarded location should find the nearest server when lat/lon are known.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/201)
<!-- Reviewable:end -->
