### PR TITLE
Only check business hours when experiment is ndt_ssl

### DIFF
--- a/server/mlabns/tests/test_reverse_proxy.py
+++ b/server/mlabns/tests/test_reverse_proxy.py
@@ -117,7 +117,8 @@ class ReverseProxyTest(unittest2.TestCase):
 
         self.assertEqual(url, "")
 
-    def test_try_reverse_proxy_url_when_outside_business_returns_emptystr(self):
+    def test_try_reverse_proxy_url_when_outside_business(self):
+        # This should return an empty string only for ndt_ssl.
         ndt_ssl_probability = model.ReverseProxyProbability(
             name="ndt_ssl",
             probability=1.0,
@@ -130,6 +131,23 @@ class ReverseProxyTest(unittest2.TestCase):
         url = reverse_proxy.try_reverse_proxy_url(mock_request, t)
 
         self.assertEqual(url, "")
+
+        ndt7_probability = model.ReverseProxyProbability(
+            name="ndt7",
+            probability=1.0,
+            url="https://fake.appspot.com")
+        ndt7_probability.put()
+        mock_request = mock.Mock()
+        mock_request.path = '/ndt7'
+        mock_request.path_qs = '/ndt7'
+        mock_request.latitude = 40.7
+        mock_request.longitude = 74.0
+        t = datetime.datetime(2019, 1, 25, 16, 0, 0)
+
+        url = reverse_proxy.try_reverse_proxy_url(mock_request, t)
+
+        self.assertEqual(url, (
+            'https://fake.appspot.com/ndt7?lat=40.700000&lon=74.000000'))
 
     def test_try_reverse_proxy_url_returns_url_with_latlon(self):
         ndt_ssl_probability = model.ReverseProxyProbability(

--- a/server/mlabns/util/reverse_proxy.py
+++ b/server/mlabns/util/reverse_proxy.py
@@ -82,7 +82,7 @@ def try_reverse_proxy_url(query, t):
     rdp = get_reverse_proxy(experiment)
     if random.uniform(0, 1) > rdp.probability:
         return ""
-    if not during_business_hours(t):
+    if query.path == '/ndt_ssl' and not during_business_hours(t):
         return ""
 
     latlon = 'lat=%f&lon=%f' % (query.latitude, query.longitude)

--- a/server/mlabns/util/reverse_proxy.py
+++ b/server/mlabns/util/reverse_proxy.py
@@ -80,6 +80,9 @@ def try_reverse_proxy_url(query, t):
 
     experiment = query.path.strip('/')
     rdp = get_reverse_proxy(experiment)
+
+    # ndt_ssl is only proxied during EST business hours, ndt7 doesn't have
+    # this restriction.
     if random.uniform(0, 1) > rdp.probability:
         return ""
     if query.path == '/ndt_ssl' and not during_business_hours(t):


### PR DESCRIPTION
This PR makes sure that the business hours restriction when evaluating the reverse proxy probability is only applied to `/ndt_ssl`.

I think this was an oversight and we meant to always redirect `/ndt7` to staging nodes in this phase, regardless of the time of day/day of the week.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/203)
<!-- Reviewable:end -->
