### PR TITLE
Handle gracefully the case where MaxMind has no information for a particular IP

### DIFF
--- a/server/mlabns/handlers/lookup.py
+++ b/server/mlabns/handlers/lookup.py
@@ -416,7 +416,9 @@ class LookupHandler(webapp.RequestHandler):
         sliver_tool = sliver_tools[0]
 
         # Lookup the maxmind information.
-        query._set_maxmind_geolocation(query.ip_address, None, None)
+        status = query._set_maxmind_geolocation(query.ip_address, None, None)
+        if not status:
+            return False
 
         # Calculate the difference between the two systems.
         difference = distance.distance(

--- a/server/mlabns/handlers/lookup.py
+++ b/server/mlabns/handlers/lookup.py
@@ -415,10 +415,10 @@ class LookupHandler(webapp.RequestHandler):
         # Log only the first (closest) site.
         sliver_tool = sliver_tools[0]
 
-        # Lookup the maxmind information.
-        status = query._set_maxmind_geolocation(query.ip_address, None, None)
-        if not status:
-            return False
+        # Lookup the maxmind information, if it doesn't exist, then just
+        # return.
+        if not query._set_maxmind_geolocation(query.ip_address, None, None):
+            return
 
         # Calculate the difference between the two systems.
         difference = distance.distance(

--- a/server/mlabns/util/lookup_query.py
+++ b/server/mlabns/util/lookup_query.py
@@ -231,6 +231,11 @@ class LookupQuery:
         self._maxmind_latitude = geo_record.latitude
         self._maxmind_longitude = geo_record.longitude
 
+        if not geo_record:
+            return False
+        else:
+            return True
+
     def _set_appengine_geolocation(self, request):
         """Adds geolocation info using the data provided by AppEngine.
 

--- a/server/mlabns/util/lookup_query.py
+++ b/server/mlabns/util/lookup_query.py
@@ -226,15 +226,16 @@ class LookupQuery:
             geo_record = maxmind.get_city_geolocation(city, country)
         elif country is not None:
             geo_record = maxmind.get_country_geolocation(country)
+
+        if geo_record.latitude == None or geo_record.longitude == None:
+            return False
+
         self._maxmind_city = geo_record.city
         self._maxmind_country = geo_record.country
         self._maxmind_latitude = geo_record.latitude
         self._maxmind_longitude = geo_record.longitude
 
-        if not geo_record:
-            return False
-        else:
-            return True
+        return True
 
     def _set_appengine_geolocation(self, request):
         """Adds geolocation info using the data provided by AppEngine.


### PR DESCRIPTION
Currently, we are seeing quite a lot (hundreds per hour) of python exceptions like this:

```
unsupported operand type(s) for -: 'NoneType' and 'float' (/base/alloc/tmpfs/dynamic_runtimes/python27g/941d77da994078b1/python27/python27_lib/versions/third_party/webapp2-2.5.1/webapp2.py:1553)
Traceback (most recent call last):
  File "/base/alloc/tmpfs/dynamic_runtimes/python27g/941d77da994078b1/python27/python27_lib/versions/third_party/webapp2-2.5.1/webapp2.py", line 1536, in __call__
    rv = self.handle_exception(request, response, e)
  File "/base/alloc/tmpfs/dynamic_runtimes/python27g/941d77da994078b1/python27/python27_lib/versions/third_party/webapp2-2.5.1/webapp2.py", line 1530, in __call__
    rv = self.router.dispatch(request, response)
  File "/base/alloc/tmpfs/dynamic_runtimes/python27g/941d77da994078b1/python27/python27_lib/versions/third_party/webapp2-2.5.1/webapp2.py", line 1278, in default_dispatcher
    return route.handler_adapter(request, response)
  File "/base/alloc/tmpfs/dynamic_runtimes/python27g/941d77da994078b1/python27/python27_lib/versions/third_party/webapp2-2.5.1/webapp2.py", line 1102, in __call__
    return handler.dispatch()
  File "/base/alloc/tmpfs/dynamic_runtimes/python27g/941d77da994078b1/python27/python27_lib/versions/third_party/webapp2-2.5.1/webapp2.py", line 572, in dispatch
    return self.handle_exception(e, self.app.debug)
  File "/base/alloc/tmpfs/dynamic_runtimes/python27g/941d77da994078b1/python27/python27_lib/versions/third_party/webapp2-2.5.1/webapp2.py", line 570, in dispatch
    return method(*args, **kwargs)
  File "/base/data/home/apps/s~mlab-ns/20190625t151456.419155451568685717/mlabns/handlers/lookup.py", line 101, in get
    self.log_location(query, sliver_tools)
  File "/base/data/home/apps/s~mlab-ns/20190625t151456.419155451568685717/mlabns/handlers/lookup.py", line 424, in log_location
    query._maxmind_longitude)
  File "/base/data/home/apps/s~mlab-ns/20190625t151456.419155451568685717/mlabns/util/distance.py", line 22, in distance
    dlat = math.radians(lat2 - lat1)
TypeError: unsupported operand type(s) for -: 'NoneType' and 'float'
```

This PR attempts to head off these exceptions by simply doing nothing if MaxMind doesn't know about a particular IP.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/204)
<!-- Reviewable:end -->
