### PR TITLE
Changes location of return statement

### DIFF
--- a/server/mlabns/util/lookup_query.py
+++ b/server/mlabns/util/lookup_query.py
@@ -232,10 +232,7 @@ class LookupQuery:
         self._maxmind_latitude = geo_record.latitude
         self._maxmind_longitude = geo_record.longitude
 
-        if geo_record.latitude == None or geo_record.longitude == None:
-            return False
-        else:
-            return True
+        return (geo_record.latitude is not None and geo_record.longitude is not None)
 
     def _set_appengine_geolocation(self, request):
         """Adds geolocation info using the data provided by AppEngine.

--- a/server/mlabns/util/lookup_query.py
+++ b/server/mlabns/util/lookup_query.py
@@ -227,15 +227,15 @@ class LookupQuery:
         elif country is not None:
             geo_record = maxmind.get_country_geolocation(country)
 
-        if geo_record.latitude == None or geo_record.longitude == None:
-            return False
-
         self._maxmind_city = geo_record.city
         self._maxmind_country = geo_record.country
         self._maxmind_latitude = geo_record.latitude
         self._maxmind_longitude = geo_record.longitude
 
-        return True
+        if geo_record.latitude == None or geo_record.longitude == None:
+            return False
+        else:
+            return True
 
     def _set_appengine_geolocation(self, request):
         """Adds geolocation info using the data provided by AppEngine.

--- a/server/mlabns/util/lookup_query.py
+++ b/server/mlabns/util/lookup_query.py
@@ -232,7 +232,8 @@ class LookupQuery:
         self._maxmind_latitude = geo_record.latitude
         self._maxmind_longitude = geo_record.longitude
 
-        return (geo_record.latitude is not None and geo_record.longitude is not None)
+        return (geo_record.latitude is not None and
+                geo_record.longitude is not None)
 
     def _set_appengine_geolocation(self, request):
         """Adds geolocation info using the data provided by AppEngine.


### PR DESCRIPTION
There are apparently some things (namely, at least one unit test), which relies the values assigned to `GeoRecord()` upon initialization, even if the corresponding MaxMind lookup fails. This PR is should fix this one unit test, while not changing the motivation for PR #204.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/205)
<!-- Reviewable:end -->
