### PR TITLE
Adds an ndt7_ipv6 Prometheus query for checking aliveness.

### DIFF
--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -101,6 +101,18 @@ QUERIES = {
             label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
         )
         """),
+    'ndt7_ipv6': textwrap.dedent("""\
+        min by (experiment, machine) (
+            probe_success{service="ndt7_ipv6"} OR
+            label_replace(((node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"} -
+              node_filesystem_free_bytes{cluster="platform-cluster", mountpoint="/cache/data"}) /
+                node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"}),
+                "experiment", "ndt.iupui", "", "") < bool 0.95 OR
+            kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"} != bool 1 OR
+            lame_duck_experiment{experiment="ndt.iupui"} != bool 1 OR
+            label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
+        )
+        """),
     'neubot': textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="neubot"} OR


### PR DESCRIPTION
Currently every time the `check_status` cron job runs it emits this error:

`There is no Prometheus query for tool: ndt7_ipv6`

There is currently no `ndt7_ipv6` Prometheus query. As such, mlab-ns currently has no way to monitor whether ndt7 over IPv6 is up or down. The datastore currently has all ndt7 over IPv6 experiments flagged as "offline". This small PR just adds the Promtheus query for ndt7 over IPv6.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/206)
<!-- Reviewable:end -->
