### PR TITLE
Log experiment name when reverse proxying a request

### DIFF
--- a/server/mlabns/handlers/lookup.py
+++ b/server/mlabns/handlers/lookup.py
@@ -59,7 +59,8 @@ class LookupHandler(webapp.RequestHandler):
             # regular request handling.
             success = self.send_proxy_response(url)
             if success:
-                logging.info('[reverse_proxy],true,%s', url)
+                experiment = query.path.strip('/')
+                logging.info('[reverse_proxy],true,%s,%s', url, experiment)
                 return
 
         logging.info('Policy is %s', query.policy)


### PR DESCRIPTION
This makes it possible to create a custom log-based metric in Stackdriver and turn the experiment name into a label.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/208)
<!-- Reviewable:end -->
