### PR TITLE
Fix order of components in client signature

### DIFF
--- a/server/mlabns/tests/test_lookup_query.py
+++ b/server/mlabns/tests/test_lookup_query.py
@@ -56,6 +56,7 @@ class LookupQueryTestCase(unittest2.TestCase):
                                                     self.mock_gae_longitude),
             message.HEADER_CITY: self.mock_gae_city,
             message.HEADER_COUNTRY: self.mock_gae_country,
+            message.USER_AGENT: 'fake user agent'
         }
 
     def testDefaultConstructor(self):
@@ -512,6 +513,14 @@ class LookupQueryTestCase(unittest2.TestCase):
 
         self.assertEqual(message.POLICY_METRO, query.policy)
         self.assertEqual('lax', query.metro)
+
+    def testGenerateClientSignature(self):
+        self.mock_request.path_qs = '/ndt'
+
+        query = lookup_query.LookupQuery()
+        query.initialize_from_http_request(self.mock_request)
+        self.assertEqual('1.2.3.4#fake user agent#/ndt',
+                         query.calculate_client_signature())
 
 
 if __name__ == '__main__':

--- a/server/mlabns/util/lookup_query.py
+++ b/server/mlabns/util/lookup_query.py
@@ -332,7 +332,8 @@ class LookupQuery:
 
             # At least 40 characters are allocated to the resource part.
             res_min_size = 40
-            res_max_size = key_max_size - len(self.ip_address) - len(resource) - 2
+            res_max_size = key_max_size - len(self.ip_address) - len(
+                resource) - 2
 
             if res_max_size < res_min_size:
                 res_max_size = res_min_size
@@ -341,8 +342,8 @@ class LookupQuery:
                 resource = resource[:res_max_size]
 
             # The remaining length is available for the User Agent part
-            ua_max_size = (key_max_size - len(self.ip_address) -
-                           len(resource) - 2)
+            ua_max_size = (
+                key_max_size - len(self.ip_address) - len(resource) - 2)
             if len(user_agent) > ua_max_size:
                 user_agent = user_agent[:ua_max_size]
 

--- a/server/mlabns/util/lookup_query.py
+++ b/server/mlabns/util/lookup_query.py
@@ -323,5 +323,5 @@ class LookupQuery:
         """
         # NB: do not check for self.user_agent, because it can be empty.
         if self.ip_address and self.path_qs:
-            return "%s#%s#%s" % (self.user_agent, self.path_qs, self.ip_address)
+            return "%s#%s#%s" % (self.ip_address, self.user_agent, self.path_qs)
         return ''

--- a/server/mlabns/util/lookup_query.py
+++ b/server/mlabns/util/lookup_query.py
@@ -323,5 +323,11 @@ class LookupQuery:
         """
         # NB: do not check for self.user_agent, because it can be empty.
         if self.ip_address and self.path_qs:
-            return "%s#%s#%s" % (self.ip_address, self.user_agent, self.path_qs)
+            key = "%s#%s#%s" % (self.ip_address, self.user_agent, self.path_qs)
+            # Memcache keys cannot be longer than 250 characters. The same
+            # truncation is applied in rate-limiter.
+            if len(key) > 250:
+                key = key[:250]
+
+            return key
         return ''


### PR DESCRIPTION
This has been changed in rate-limiter so that the order is IP#UA#resource.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/210)
<!-- Reviewable:end -->
