### PR TITLE
Adds Tool neubot_tls[_ipv6]

### DIFF
--- a/server/mlabns/conf/tools.csv
+++ b/server/mlabns/conf/tools.csv
@@ -3,4 +3,5 @@ ndt,iupui_ndt,7123,False,prometheus
 ndt_ssl,iupui_ndt,,False,prometheus
 ndt7,iupui_ndt,,False,prometheus
 mobiperf,michigan_1,,False,prometheus
-neubot,mlab_neubot,8080,False,prometheus
+neubot,mlab_neubot,80,False,prometheus
+neubot_tls,mlab_neubot,443,False,prometheus

--- a/server/mlabns/util/fqdn_rewrite.py
+++ b/server/mlabns/util/fqdn_rewrite.py
@@ -4,6 +4,15 @@ import logging
 
 from mlabns.util import message
 
+# List of `tool_id`s that require FQDNs to be rewritten using "flattened" names
+# to accommodate the *.measurement-lab.org wildcard certificate.
+# TODO (nkinkade): This would be more cleanly implemented as a property of the
+# Tool in GCD.
+FLAT_HOSTNAMES = [
+    'ndt7',
+    'ndt_ssl',
+    'neubot_tls',
+]
 
 def rewrite(fqdn, address_family, tool_id):
     """Rewrites an FQDN to add necessary annotations and special-casing.
@@ -22,9 +31,9 @@ def rewrite(fqdn, address_family, tool_id):
         FQDN after rewriting to apply all modifications to the raw FQDN.
     """
     rewritten_fqdn = _apply_af_awareness(fqdn, address_family)
-    # If this is ndt_ssl or ndt7, apply the special case workaround.
-    if tool_id == 'ndt_ssl' or tool_id == 'ndt7':
-        rewritten_fqdn = _apply_ndt_ssl_workaround(rewritten_fqdn)
+    # If this Tool requires "flat" hostname, rewrite it.
+    if tool_id in FLAT_HOSTNAMES:
+        rewritten_fqdn = _apply_flat_hostname(rewritten_fqdn)
     return rewritten_fqdn
 
 
@@ -61,29 +70,22 @@ def _apply_af_awareness(fqdn, address_family):
     return '.'.join(fqdn_parts)
 
 
-def _apply_ndt_ssl_workaround(fqdn):
-    """Rewrites ndt_ssl/ndt7 FQDNs to use dash separators for subdomains.
-
-    The NDT-SSL test uses dashes instead of dots as separators in the subdomain,
-    but Nagios currently reports the FQDNs as using dots.
+def _apply_flat_hostname(fqdn):
+    """Rewrites FQDNs to use dash separators for subdomains.
 
     For example, instead of:
 
         ndt.iupui.mlab1.lga06.measurement-lab.org
 
-    NDT-SSL uses:
+    TLS endpoints use:
 
         ndt-iupui-mlab1-lga06.measurement-lab.org
 
-    We rewrite the dotted FQDNs to use dashes so that NDT-SSL/ndt7 work
-    properly. This is intended to be a temporary workaround until we can
-    find a solution that does not require NDT-SSL/ndt7 to be special cases
-    from mlab-ns's perspective.
-
-    See https://github.com/m-lab/mlab-ns/issues/48 for more information.
+    We rewrite the dotted FQDNs to use dashes so that FQDNs work
+    properly with the *.measurement-lab.org wildcard certificate.
 
     Args:
-        fqdn: An NDT-SSL or ndt7 FQDN in dotted notation.
+        fqdn: An FQDN in dotted notation.
 
     Returns:
         FQDN with rewritten dashes if a rewrite was necessary, the original FQDN

--- a/server/mlabns/util/fqdn_rewrite.py
+++ b/server/mlabns/util/fqdn_rewrite.py
@@ -14,6 +14,7 @@ FLAT_HOSTNAMES = [
     'neubot_tls',
 ]
 
+
 def rewrite(fqdn, address_family, tool_id):
     """Rewrites an FQDN to add necessary annotations and special-casing.
 

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -29,8 +29,7 @@ from mlabns.util import message
 # as intended. label_replace() here just manually adds the experiment label to
 # every result with a static value.
 QUERIES = {
-    'ndt':
-    textwrap.dedent("""\
+    'ndt': textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="ndt_raw"} OR
             script_success{service="ndt_e2e"} OR
@@ -45,8 +44,7 @@ QUERIES = {
             label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
         )
         """),
-    'ndt_ipv6':
-    textwrap.dedent("""\
+    'ndt_ipv6': textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="ndt_raw_ipv6"} OR
             script_success{service="ndt_e2e"} OR
@@ -61,8 +59,7 @@ QUERIES = {
             label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
         )
         """),
-    'ndt_ssl':
-    textwrap.dedent("""\
+    'ndt_ssl': textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="ndt_ssl"} OR
             script_success{service="ndt_e2e"} OR
@@ -77,8 +74,7 @@ QUERIES = {
             label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
         )
         """),
-    'ndt_ssl_ipv6':
-    textwrap.dedent("""\
+    'ndt_ssl_ipv6': textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="ndt_ssl_ipv6"} OR
             script_success{service="ndt_e2e"} OR
@@ -93,8 +89,7 @@ QUERIES = {
             label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
         )
         """),
-    'ndt7':
-    textwrap.dedent("""\
+    'ndt7': textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="ndt7"} OR
             label_replace(((node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"} -
@@ -106,8 +101,7 @@ QUERIES = {
             label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
         )
         """),
-    'ndt7_ipv6':
-    textwrap.dedent("""\
+    'ndt7_ipv6': textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="ndt7_ipv6"} OR
             label_replace(((node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"} -
@@ -119,8 +113,7 @@ QUERIES = {
             label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
         )
         """),
-    'neubot':
-    textwrap.dedent("""\
+    'neubot': textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="neubot"} OR
             kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"} != bool 1 OR
@@ -128,8 +121,7 @@ QUERIES = {
             label_replace(gmx_machine_maintenance, "experiment", "neubot.mlab", "", "") != bool 1
         )
         """),
-    'neubot_ipv6':
-    textwrap.dedent("""\
+    'neubot_ipv6': textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="neubot_ipv6"} OR
             kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"} != bool 1 OR
@@ -137,8 +129,7 @@ QUERIES = {
             label_replace(gmx_machine_maintenance, "experiment", "neubot.mlab", "", "") != bool 1
         )
         """),
-    'neubot_tls':
-    textwrap.dedent("""\
+    'neubot_tls': textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="neubot_tls"} OR
             kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"} != bool 1 OR
@@ -146,8 +137,7 @@ QUERIES = {
             label_replace(gmx_machine_maintenance, "experiment", "neubot.mlab", "", "") != bool 1
         )
         """),
-    'neubot_tls_ipv6':
-    textwrap.dedent("""\
+    'neubot_tls_ipv6': textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="neubot_tls_ipv6"} OR
             kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"} != bool 1 OR
@@ -155,8 +145,7 @@ QUERIES = {
             label_replace(gmx_machine_maintenance, "experiment", "neubot.mlab", "", "") != bool 1
         )
         """),
-    'mobiperf':
-    textwrap.dedent("""\
+    'mobiperf': textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="mobiperf", instance=~".*:6001"} OR
             probe_success{service="mobiperf", instance=~".*:6002"} OR
@@ -166,8 +155,7 @@ QUERIES = {
             label_replace(gmx_machine_maintenance, "experiment", "1.michigan", "", "") != bool 1
         )
         """),
-    'mobiperf_ipv6':
-    textwrap.dedent("""\
+    'mobiperf_ipv6': textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="mobiperf_ipv6", instance=~".*:6001"} OR
             probe_success{service="mobiperf_ipv6", instance=~".*:6002"} OR

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -29,7 +29,8 @@ from mlabns.util import message
 # as intended. label_replace() here just manually adds the experiment label to
 # every result with a static value.
 QUERIES = {
-    'ndt': textwrap.dedent("""\
+    'ndt':
+    textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="ndt_raw"} OR
             script_success{service="ndt_e2e"} OR
@@ -44,7 +45,8 @@ QUERIES = {
             label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
         )
         """),
-    'ndt_ipv6': textwrap.dedent("""\
+    'ndt_ipv6':
+    textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="ndt_raw_ipv6"} OR
             script_success{service="ndt_e2e"} OR
@@ -59,7 +61,8 @@ QUERIES = {
             label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
         )
         """),
-    'ndt_ssl': textwrap.dedent("""\
+    'ndt_ssl':
+    textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="ndt_ssl"} OR
             script_success{service="ndt_e2e"} OR
@@ -74,7 +77,8 @@ QUERIES = {
             label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
         )
         """),
-    'ndt_ssl_ipv6': textwrap.dedent("""\
+    'ndt_ssl_ipv6':
+    textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="ndt_ssl_ipv6"} OR
             script_success{service="ndt_e2e"} OR
@@ -89,7 +93,8 @@ QUERIES = {
             label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
         )
         """),
-    'ndt7': textwrap.dedent("""\
+    'ndt7':
+    textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="ndt7"} OR
             label_replace(((node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"} -
@@ -101,7 +106,8 @@ QUERIES = {
             label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
         )
         """),
-    'ndt7_ipv6': textwrap.dedent("""\
+    'ndt7_ipv6':
+    textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="ndt7_ipv6"} OR
             label_replace(((node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"} -
@@ -113,7 +119,8 @@ QUERIES = {
             label_replace(gmx_machine_maintenance, "experiment", "ndt.iupui", "", "") != bool 1
         )
         """),
-    'neubot': textwrap.dedent("""\
+    'neubot':
+    textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="neubot"} OR
             kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"} != bool 1 OR
@@ -121,7 +128,8 @@ QUERIES = {
             label_replace(gmx_machine_maintenance, "experiment", "neubot.mlab", "", "") != bool 1
         )
         """),
-    'neubot_ipv6': textwrap.dedent("""\
+    'neubot_ipv6':
+    textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="neubot_ipv6"} OR
             kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"} != bool 1 OR
@@ -129,7 +137,26 @@ QUERIES = {
             label_replace(gmx_machine_maintenance, "experiment", "neubot.mlab", "", "") != bool 1
         )
         """),
-    'mobiperf': textwrap.dedent("""\
+    'neubot_tls':
+    textwrap.dedent("""\
+        min by (experiment, machine) (
+            probe_success{service="neubot_tls"} OR
+            kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"} != bool 1 OR
+            lame_duck_experiment{experiment="neubot.mlab"} != bool 1 OR
+            label_replace(gmx_machine_maintenance, "experiment", "neubot.mlab", "", "") != bool 1
+        )
+        """),
+    'neubot_tls_ipv6':
+    textwrap.dedent("""\
+        min by (experiment, machine) (
+            probe_success{service="neubot_tls_ipv6"} OR
+            kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"} != bool 1 OR
+            lame_duck_experiment{experiment="neubot.mlab"} != bool 1 OR
+            label_replace(gmx_machine_maintenance, "experiment", "neubot.mlab", "", "") != bool 1
+        )
+        """),
+    'mobiperf':
+    textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="mobiperf", instance=~".*:6001"} OR
             probe_success{service="mobiperf", instance=~".*:6002"} OR
@@ -139,7 +166,8 @@ QUERIES = {
             label_replace(gmx_machine_maintenance, "experiment", "1.michigan", "", "") != bool 1
         )
         """),
-    'mobiperf_ipv6': textwrap.dedent("""\
+    'mobiperf_ipv6':
+    textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="mobiperf_ipv6", instance=~".*:6001"} OR
             probe_success{service="mobiperf_ipv6", instance=~".*:6002"} OR
@@ -178,14 +206,16 @@ class PrometheusSliceInfo(object):
         self._address_family = address_family
 
     def __eq__(self, other):
-        return all([self.slice_url == other.slice_url,
-                    self.tool_id == other.tool_id,
-                    self.address_family == other.address_family])
+        return all([
+            self.slice_url == other.slice_url, self.tool_id == other.tool_id,
+            self.address_family == other.address_family
+        ])
 
     def __ne__(self, other):
-        return any([self.slice_url != other.slice_url,
-                    self.tool_id != other.tool_id,
-                    self.address_family != other.address_family])
+        return any([
+            self.slice_url != other.slice_url, self.tool_id != other.tool_id,
+            self.address_family != other.address_family
+        ])
 
     @property
     def slice_url(self):


### PR DESCRIPTION
Neubot on the new platform cluster now supports TLS for the DASH test. This PR adds a new tool `neubot_tls`. This PR is complementary to PR https://github.com/m-lab/prometheus-support/pull/571.

This PR also drags along some formatting changes automatically suggested in vscode (using yapf --style google).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/213)
<!-- Reviewable:end -->
