### PR TITLE
Removes /neubot_tls query path

### DIFF
--- a/server/mlabns/conf/tools.csv
+++ b/server/mlabns/conf/tools.csv
@@ -4,4 +4,3 @@ ndt_ssl,iupui_ndt,,False,prometheus
 ndt7,iupui_ndt,,False,prometheus
 mobiperf,michigan_1,,False,prometheus
 neubot,mlab_neubot,80,False,prometheus
-neubot_tls,mlab_neubot,443,False,prometheus

--- a/server/mlabns/util/fqdn_rewrite.py
+++ b/server/mlabns/util/fqdn_rewrite.py
@@ -11,7 +11,7 @@ from mlabns.util import message
 FLAT_HOSTNAMES = [
     'ndt7',
     'ndt_ssl',
-    'neubot_tls',
+    'neubot',
 ]
 
 

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -116,6 +116,7 @@ QUERIES = {
     'neubot': textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="neubot"} OR
+            probe_success{service="neubot_tls"} OR
             kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"} != bool 1 OR
             lame_duck_experiment{experiment="neubot.mlab"} != bool 1 OR
             label_replace(gmx_machine_maintenance, "experiment", "neubot.mlab", "", "") != bool 1
@@ -124,21 +125,6 @@ QUERIES = {
     'neubot_ipv6': textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="neubot_ipv6"} OR
-            kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"} != bool 1 OR
-            lame_duck_experiment{experiment="neubot.mlab"} != bool 1 OR
-            label_replace(gmx_machine_maintenance, "experiment", "neubot.mlab", "", "") != bool 1
-        )
-        """),
-    'neubot_tls': textwrap.dedent("""\
-        min by (experiment, machine) (
-            probe_success{service="neubot_tls"} OR
-            kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"} != bool 1 OR
-            lame_duck_experiment{experiment="neubot.mlab"} != bool 1 OR
-            label_replace(gmx_machine_maintenance, "experiment", "neubot.mlab", "", "") != bool 1
-        )
-        """),
-    'neubot_tls_ipv6': textwrap.dedent("""\
-        min by (experiment, machine) (
             probe_success{service="neubot_tls_ipv6"} OR
             kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"} != bool 1 OR
             lame_duck_experiment{experiment="neubot.mlab"} != bool 1 OR


### PR DESCRIPTION
We decided to stick with only `/neubot` and `/neubot_ipv6` mlab-ns tools for Neubot. And we also decided to return "flat" host names for both so that the fqdns work with M-Lab wildcard cert by default.

With this PR, mlab-ns will now consider a neubot pod down if a probe of _either_ port 80 or 443 fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/214)
<!-- Reviewable:end -->
