### PR TITLE
Fix Dockerfile to remain py2.7 compatible

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,10 +1,19 @@
-FROM google/cloud-sdk
+FROM ubuntu
 
-ENV PYTHONPATH $PYTHONPATH:/usr/lib/google-cloud-sdk/platform/google_appengine
+ENV PYTHONPATH $PYTHONPATH:/usr/local/google-cloud-sdk/platform/google_appengine
 # NOTE: the Cloud SDK component manager is disabled in this install, so
 # `gcloud components install app-engine-python` does not work. So, use:
 RUN apt-get update
-RUN apt-get install -y google-cloud-sdk-app-engine-python
+RUN apt-get install -y wget python-pip vim
+
+# Setup google-cloud-sdk.
+WORKDIR /usr/local/
+RUN wget https://dl.google.com/dl/cloudsdk/channels/rapid/downloads/google-cloud-sdk-277.0.0-linux-x86_64.tar.gz
+RUN tar -zxf google-cloud-sdk-277.0.0-linux-x86_64.tar.gz
+RUN rm -f google-cloud-sdk-277.0.0-linux-x86_64.tar.gz
+ENV PATH $PATH:/usr/local/google-cloud-sdk/bin
+RUN gcloud components install app-engine-python app-engine-python-extras
+
 COPY test_requirements.txt /
 RUN pip install -r /test_requirements.txt
 RUN pip install coveralls


### PR DESCRIPTION
The previous base image no longer supports python2.7 natively.

This change updates the Dockerfile to remain py2.7 compatible for a little longer.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/218)
<!-- Reviewable:end -->
