### PR TITLE
Add candidate v2 api for QueryResult

### DIFF
--- a/v2/api.go
+++ b/v2/api.go
@@ -1,0 +1,58 @@
+package v2
+
+import "time"
+
+// QueryResult is returned by the location service in response to query
+// requests.
+type QueryResult struct {
+
+	// Error contains information about request failures.
+	Error *Error `json:"error,omitempty"`
+
+	// NextRequestAfter is the earliest time that a client should make a new
+	// request.
+	//
+	// Under normal circumstances, this time is provided *with* Results. The
+	// time is sampled from an exponential distribution such that inter-request
+	// times are memoryless. Under abnormal circumstances, such as high
+	// single-client request rates or target capacity exhaustion, this time is
+	// provided *without* Results.
+	//
+	// Non-interactive or batch clients SHOULD schedule measurements with this
+	// value. All clients SHOULD NOT make additional requests until
+	// NextRequestAfter. The server MAY reject requests indefinitely when
+	// clients fail to respect this limit.
+	NextRequestAfter *time.Time `json:"next_request_after,omitempty"`
+
+	// Results contains an array of Targets matching the client request.
+	Results []Target `json:"results,omitempty"`
+}
+
+// Target contains information needed to run a measurement to a measurement
+// service on a single M-Lab machine. Measurement services may support multiple
+// resources. A Target contains at least one measurement service resource in
+// URLs.
+type Target struct {
+
+	// Machine is the FQDN of the machine hosting the measurement service.
+	Machine string `json:"machine"`
+
+	// URLs contains measurement service resource names and the complete URL for
+	// running a measurement.
+	//
+	// A measurement service may support multiple resources (e.g. upload,
+	// download, etc). Each key is a resource name and the value is a complete
+	// URL with protocol, service name, port, and parameters fully specified.
+	URLs map[string]string `json:"urls"`
+}
+
+// Error describes an error condition that prevents the server from completing a
+// QueryResult.
+type Error struct {
+	// RFC7807 Fields for "Problem Details".
+	Type     string `json:"type"`
+	Title    string `json:"title"`
+	Status   int    `json:"status"`
+	Detail   string `json:"detail,omitempty"`
+	Instance string `json:"instance,omitempty"`
+}

--- a/v2/api.go
+++ b/v2/api.go
@@ -50,14 +50,14 @@ type QueryResult struct {
 // priority class.
 type NextRequest struct {
 	// NotBefore defines the time after which the URL will become valid. This
-	// value is the same time used in "nbf" field of the underlying JWT claim. To
-	// show this equivalence, we use the same name.
-	NotBefore time.Time `json:"not_before"`
+	// value is the same time used in "nbf" field of the underlying JSON Web
+	// Token (JWT) claim. To show this equivalence, we use the same name.
+	NotBefore time.Time `json:"nbf"`
 
 	// Expires defines the time after which the URL will be invalid. Expires will
 	// always be greater than NotBefore. This value is the same time used in the
 	// "exp" field of the underlying JWT claim.
-	Expires time.Time `json:"expires"`
+	Expires time.Time `json:"exp"`
 
 	// URL should be used to make the next request to the location service.
 	URL string `json:"url"`

--- a/v2/api.go
+++ b/v2/api.go
@@ -21,7 +21,6 @@ import "time"
 // QueryResult is returned by the location service in response to query
 // requests.
 type QueryResult struct {
-
 	// Error contains information about request failures.
 	Error *Error `json:"error,omitempty"`
 
@@ -50,9 +49,18 @@ type QueryResult struct {
 // will be handled as if no access token were provided, i.e. using a lower
 // priority class.
 type NextRequest struct {
-	NotBefore time.Time `json:"not_before"` // Valid after.
-	Expires   time.Time `json:"expires"`    // Valid until.
-	URL       string    `json:"url"`
+	// NotBefore defines the time after which the URL will become valid. This
+	// value is the same time used in "nbf" field of the underlying JWT claim. To
+	// show this equivalence, we use the same name.
+	NotBefore time.Time `json:"not_before"`
+
+	// Expires defines the time after which the URL will be invalid. Expires will
+	// always be greater than NotBefore. This value is the same time used in the
+	// "exp" field of the underlying JWT claim.
+	Expires time.Time `json:"expires"`
+
+	// URL should be used to make the next request to the location service.
+	URL string `json:"url"`
 }
 
 // Target contains information needed to run a measurement to a measurement
@@ -60,7 +68,6 @@ type NextRequest struct {
 // resources. A Target contains at least one measurement service resource in
 // URLs.
 type Target struct {
-
 	// Machine is the FQDN of the machine hosting the measurement service.
 	Machine string `json:"machine"`
 


### PR DESCRIPTION
Part of https://github.com/m-lab/dev-tracker/issues/460

This change introduces a candidate location service v2 api for a `QueryResult`.

The current fields are intended to be the minimal set, not the complete set. For example, additional target geo information may be helpful in the future, or a summary of where the location service believes the client is located to help uncover mismatched geo lookups.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/219)
<!-- Reviewable:end -->
