### PR TITLE
Skip 1g sites for single-server responses

### DIFF
--- a/server/mlabns/util/resolver.py
+++ b/server/mlabns/util/resolver.py
@@ -131,6 +131,9 @@ class GeoResolver(ResolverBase):
                                          candidates)
 
         for candidate in filtered_candidates:
+            if max_results == 1 and candidate.site_id in site_keep_probability:
+                # Skip 1g sites if we're returning a single result.
+                continue
             prob = site_keep_probability.get(candidate.site_id, 1.0)
             if random.uniform(0, 1) < prob:
                 # Only add candidate if a random probability is under the "site


### PR DESCRIPTION
Fixes https://github.com/m-lab/mlab-ns/issues/225

For GeoResolver results requesting a single site, this change prevents ever returning 1g sites.

The rationale behind this is to prevent sending clients to tx-controller enabled 1g sites when rejected requests cannot fallback on a next server (which would be available when more than one server is returned). While it's still possible for 10g sites to reject requests the probability is much lower and the demand on such sites would be so high that most clients would be having a bad time under those conditions.

The consequence of this is client bias at 1g sites.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/226)
<!-- Reviewable:end -->
