### PR TITLE
Revert "Skip 1g sites for single-server responses"

### DIFF
--- a/server/mlabns/util/resolver.py
+++ b/server/mlabns/util/resolver.py
@@ -131,9 +131,6 @@ class GeoResolver(ResolverBase):
                                          candidates)
 
         for candidate in filtered_candidates:
-            if max_results == 1 and candidate.site_id in site_keep_probability:
-                # Skip 1g sites if we're returning a single result.
-                continue
             prob = site_keep_probability.get(candidate.site_id, 1.0)
             if random.uniform(0, 1) < prob:
                 # Only add candidate if a random probability is under the "site


### PR DESCRIPTION
Reverts m-lab/mlab-ns#226

Upon consideration, and discussion -- this may be a bad idea b/c it distorts traffic for all clients in areas with 1g singleton sites like all of Canada.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/227)
<!-- Reviewable:end -->
