### PR TITLE
One regex to match all input in parse_fqdn.py + unit testing updates

### DIFF
--- a/server/mlabns/db/model.py
+++ b/server/mlabns/db/model.py
@@ -195,6 +195,10 @@ def get_slice_site_server_ids(fqdn):
     if not p:
         return None, None, None
 
+    # If any one of these values is missing, then the whole thing fails.
+    if not p['experiment'] or not p['machine'] or not p['site']:
+        return None, None, None
+
     if p['org']:
         experiment = '%s_%s' % (p['org'], p['experiment'])
     else:

--- a/server/mlabns/tests/test_parse_fqdn.py
+++ b/server/mlabns/tests/test_parse_fqdn.py
@@ -1,0 +1,115 @@
+import unittest
+
+from mlabns.util import parse_fqdn
+
+
+class ParseFqdnTest(unittest.TestCase):
+
+    def testValidV1ExperimentFqdnWithOrg(self):
+        """A valid v1 experiment FQDN, with org."""
+        fqdn = 'ndt.iupui.mlab4.lga06.measurement-lab.org'
+        expected = {
+            'experiment': 'ndt',
+            'org': 'iupui',
+            'machine': 'mlab4',
+            'site': 'lga06',
+            'project': None,
+            'domain': 'measurement-lab.org',
+        }
+        actual = parse_fqdn.parse(fqdn)
+        self.assertEqual(expected, actual)
+
+    def testValidV1ExperimentFqdnWithoutOrg(self):
+        """A valid v1 experiment FQDN, without org."""
+        fqdn = 'wehe.mlab4.lga06.measurement-lab.org'
+        expected = {
+            'experiment': 'wehe',
+            'org': None,
+            'machine': 'mlab4',
+            'site': 'lga06',
+            'project': None,
+            'domain': 'measurement-lab.org',
+        }
+        actual = parse_fqdn.parse(fqdn)
+        self.assertEqual(expected, actual)
+
+    def testValidV2ExperimentFqdnWithOrg(self):
+        """A valid v2 experiment FQDN, with org."""
+        fqdn = 'ndt-iupui-mlab4-lga06.mlab-staging.measurement-lab.org'
+        expected = {
+            'experiment': 'ndt',
+            'org': 'iupui',
+            'machine': 'mlab4',
+            'site': 'lga06',
+            'project': 'mlab-staging',
+            'domain': 'measurement-lab.org',
+        }
+        actual = parse_fqdn.parse(fqdn)
+        self.assertEqual(expected, actual)
+
+    def testValidV1MachineFqdn(self):
+        """A valid v1 machine FQDN."""
+        fqdn = 'mlab2.abc03.measurement-lab.org'
+        expected = {
+            'experiment': None,
+            'org': None,
+            'machine': 'mlab2',
+            'site': 'abc03',
+            'project': None,
+            'domain': 'measurement-lab.org',
+        }
+        actual = parse_fqdn.parse(fqdn)
+        self.assertEqual(expected, actual)
+
+    def testValidV2MachineFqdn(self):
+        """A valid v2 machine FQDN."""
+        fqdn = 'mlab3-xyz03.measurement-lab.org'
+        expected = {
+            'experiment': None,
+            'org': None,
+            'machine': 'mlab3',
+            'site': 'xyz03',
+            'project': None,
+            'domain': 'measurement-lab.org',
+        }
+        actual = parse_fqdn.parse(fqdn)
+        self.assertEqual(expected, actual)
+
+    def testInvalidV1ExperimentFqdnTooManyParts(self):
+        """A invalid v1 experiment FQDN with too many experiment-org parts"""
+        fqdn = 'ndt.iupui.extra.mlab1.den05.measurement-lab.org'
+        expected = {}
+        actual = parse_fqdn.parse(fqdn)
+        self.assertEqual(expected, actual)
+
+    def testInvalidV2ExperimentFqdnTooManyParts(self):
+        """A invalid v2 experiment FQDN with too many experiment-org parts"""
+        fqdn = 'ndt-iupui-extra-mlab1-den05.mlab-oti.measurement-lab.org'
+        expected = {}
+        actual = parse_fqdn.parse(fqdn)
+        self.assertEqual(expected, actual)
+
+    def testInvalidV1ExperimentFqdnBadMachineName(self):
+        """A invalid v1 experiment FQDN with invalid machine name."""
+        fqdn = 'wehe.machine.den05.measurement-lab.org'
+        expected = {}
+        actual = parse_fqdn.parse(fqdn)
+        self.assertEqual(expected, actual)
+
+    def testInvalidV2ExperimentFqdnBadMachineName(self):
+        """A invalid v2 experiment FQDN with invalid machine name."""
+        fqdn = 'wehe-machine-den05.mlab-oti.measurement-lab.org'
+        expected = {}
+        actual = parse_fqdn.parse(fqdn)
+        self.assertEqual(expected, actual)
+
+    def testEmptyInput(self):
+        """Invalid empty string input."""
+        fqdn = ''
+        expected = {}
+        actual = parse_fqdn.parse(fqdn)
+        self.assertEqual(expected, actual)
+
+
+if __name__ == '__main__':
+    unittest.main()

--- a/server/mlabns/tests/test_production_check.py
+++ b/server/mlabns/tests/test_production_check.py
@@ -58,6 +58,14 @@ class CheckProductionTestCase(unittest.TestCase):
             'wehe.mlab.mlab1.dfw02.measurement-lab.org'))
         self.assertTrue(pc.is_production_slice(
             'ndt-iupui-mlab1-dfw03.mlab-oti.measurement-lab.org'))
+        self.assertTrue(pc.is_production_slice(
+            'mlab1-dfw03.mlab-oti.measurement-lab.org'))
+        self.assertTrue(pc.is_production_slice(
+            'mlab1.dfw03.mlab-oti.measurement-lab.org'))
+        self.assertTrue(pc.is_production_slice(
+            'mlab3.dfw02.measurement-lab.org'))
+        self.assertTrue(pc.is_production_slice(
+            'mlab3-dfw02.measurement-lab.org'))
 
         self.assertFalse(
             pc.is_production_slice('ndt.iupui.mlab4.prg01.measurement-lab.org'),
@@ -68,6 +76,10 @@ class CheckProductionTestCase(unittest.TestCase):
         self.assertFalse(
             pc.is_production_slice(
                 'ndt-iupui-mlab4-prg01.mlab-staging.measurement-lab.org'),
+            'mlab4 servers are not production slices')
+        self.assertFalse(
+            pc.is_production_slice(
+                'mlab4-abc01.mlab-staging.measurement-lab.org'),
             'mlab4 servers are not production slices')
 
         # Staging checks
@@ -80,7 +92,18 @@ class CheckProductionTestCase(unittest.TestCase):
             'neubot.mlab.mlab4.dfw0c.measurement-lab.org'))
         self.assertTrue(pc.is_production_slice(
             'wehe-mlab4-dfw02.mlab-staging.measurement-lab.org'))
+        self.assertTrue(pc.is_production_slice(
+            'mlab.mlab4.dfw0c.measurement-lab.org'))
+        self.assertTrue(pc.is_production_slice(
+            'mlab4-dfw02.mlab-staging.measurement-lab.org'))
 
+        self.assertFalse(
+            pc.is_production_slice('mlab3prg01.measurement-lab.org'),
+            'Missing separator between machine and site.')
+        self.assertFalse(
+            pc.is_production_slice(
+                'ndt-iupui-abc-mlab3.mlab-oti.prg01.measurement-lab.org'),
+            'Too many experiment-org parts.')
         self.assertFalse(
             pc.is_production_slice('ndt.iupui.mlab3.prg01.measurement-lab.org'),
             'mlab3 servers are not staging slices')
@@ -98,6 +121,10 @@ class CheckProductionTestCase(unittest.TestCase):
             'neubot.mlab.mlab1.dfw0t.measurement-lab.org'))
         self.assertTrue(pc.is_production_slice(
             'wehe-mlab4-dfw0t.mlab-staging.measurement-lab.org'))
+        self.assertTrue(pc.is_production_slice(
+            'mlab1.dfw0t.measurement-lab.org'))
+        self.assertTrue(pc.is_production_slice(
+            'mlab4-dfw0t.mlab-staging.measurement-lab.org'))
 
         self.assertFalse(
             pc.is_production_slice('ndt.iupui.mlab3.prg01.measurement-lab.org'),

--- a/server/mlabns/util/parse_fqdn.py
+++ b/server/mlabns/util/parse_fqdn.py
@@ -12,7 +12,7 @@ def parse(fqdn):
         dict representing the constituent parts.
     """
     # This regex *should* match all valid M-Lab domain names, for both nodes
-    # and experiments, for both v1 and v2 names. It makes use of non-capturging
+    # and experiments, for both v1 and v2 names. It makes use of non-capturing
     # groups denoted by '(?:)'. What is interesting is that you can specify
     # capturing groups inside of non-capturing groups.
     regex = '(?:([a-z]+)(?:[.-]([a-z]+))?[.-])?(mlab[1-4])[.-]([a-z]{3}[0-9ct]{2})(?:\.(mlab-[a-z]+))?\.(.*)$'

--- a/server/mlabns/util/parse_fqdn.py
+++ b/server/mlabns/util/parse_fqdn.py
@@ -11,43 +11,26 @@ def parse(fqdn):
     Returns:
         dict representing the constituent parts.
     """
-    # If there is a dash instead of a dot after the machine name, then this is
-    # a v2 ("flat") name, then parse the fqdn accordingly, else parse it by v1
-    # conventions.
-    if re.search('mlab[1-4]-', fqdn):
-        regex = '([a-z-]+?)-(mlab[1-4])-([a-z]{3}[0-9ct]{2})\.(mlab-[a-z]+)\.(measurement-lab.org)'
-        version = 'v2'
-    else:
-        regex = '([a-z.]+?)\.(mlab[1-4])\.([a-z]{3}[0-9ct]{2})\.(measurement-lab.org)'
-        version = 'v1'
+    # This regex *should* match all valid M-Lab domain names, for both nodes
+    # and experiments, for both v1 and v2 names. It makes use of non-capturging
+    # groups denoted by '(?:)'. What is interesting is that you can specify
+    # capturing groups inside of non-capturing groups.
+    regex = '(?:([a-z]+)(?:[.-]([a-z]+))?[.-])?(mlab[1-4])[.-]([a-z]{3}[0-9ct]{2})(?:\.(mlab-[a-z]+))?\.(.*)$'
 
     matches = re.match(regex, fqdn)
-    if not matches:
+    if not matches or len(matches.groups()) != 6:
         logging.error('Failed to parse FQDN: %s', fqdn)
         return {}
 
     parts = list(matches.groups())
 
-    fqdn_parts = {}
-
-    # If the experiment part of the FQDN has a dot or dash, then split it apart
-    # into experiment and org.
-    experiment_org = re.match('([a-z]+)([.-])([a-z]+)', parts[0])
-    if experiment_org:
-        fqdn_parts['experiment'] = experiment_org.group(1)
-        fqdn_parts['org'] = experiment_org.group(3)
-    else:
-        fqdn_parts['experiment'] = parts[0]
-        fqdn_parts['org'] = ''
-
-    if version == 'v2':
-        fqdn_parts['project'] = parts[3]
-        fqdn_parts['domain'] = parts[4]
-    else:
-        fqdn_parts['project'] = ''
-        fqdn_parts['domain'] = parts[3]
-
-    fqdn_parts['machine'] = parts[1]
-    fqdn_parts['site'] = parts[2]
+    fqdn_parts = {
+        'experiment': parts[0],
+        'org': parts[1],
+        'machine': parts[2],
+        'site': parts[3],
+        'project': parts[4],
+        'domain': parts[5],
+    }
 
     return fqdn_parts


### PR DESCRIPTION
When I wrote parse_fqdn.py I had not realized that it would need to parse machine FQDNs in addition to experiment FQDNs, which was incorrect. It does need to parse machine FQDNs. This PR introduces support for parsing machine FQDNs in addition to experiment ones.

This PR also significantly simplifies the logic in `parse_fqdn.parse()` by implementing a single regex which should match all valid input.

The PR also introduces unit testing for parse_fqdn.py. I had previously not added it, thinking that the unit testing for the other modules that utilized this module was sufficient. However, since previous unit tests did not test the case of a machine FQDN being passed, I decided it was safer to implement unit testing specific to this module.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/231)
<!-- Reviewable:end -->
