### PR TITLE
Changes a non-matching FQDN log message from error() to info().

### DIFF
--- a/server/mlabns/util/production_check.py
+++ b/server/mlabns/util/production_check.py
@@ -44,7 +44,7 @@ def is_production_slice(slice_fqdn):
             machine_regex, fqdn_parts['machine'], re.IGNORECASE):
         return True
 
-    logging.error(
+    logging.info(
         "FQDN %s did not match site_regex (%s) AND/OR machine_regex (%s)" %
         (slice_fqdn, site_regex, machine_regex))
     return False


### PR DESCRIPTION
Not matching is not an error condition, but simply a normal process. For example, mlab1.den06 will not match in staging, and mlab4.den06 will not match in production. This tiny change helps to make the mlab-ns logs look not scary when viewing them in the GCP console.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/232)
<!-- Reviewable:end -->
