### PR TITLE
Reclaim use of "locate" service name by mlab-ns

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ retained below for reference.
 ### Testing environment
 
 To deploy to the standard mlab-ns testing environment
-(locate-dot-mlab-sandbox.appspot.com), follow the instructions below with no
+(mlab-sandbox.appspot.com), follow the instructions below with no
 modifications. To deploy to a different testing environment, you may need to
 edit `server/app.yaml.mlab-sandbox` to update the "service" field to work
 within your test environment's other App Engine services names.
@@ -77,7 +77,7 @@ into the files before running the `appcfg.py` commands below.
 
 ```
 # Replace URL with other project's URL if not populating mlab-sandbox.
-GAE_URL=http://locate-dot-mlab-sandbox.appspot.com
+GAE_URL=http://mlab-sandbox.appspot.com
 TOKEN=$( gcloud auth print-access-token )
 
 appcfg.py --url ${GAE_URL}/_ah/remote_api upload_data \
@@ -115,7 +115,7 @@ Run the following jobs from GCP under Compute > App Engine > Task queues > Cron 
 1. `/cron/check_status`
 
 If bootstrapping was successful, you should see a populated map at the root
-mlab-ns URL (e.g. mlab-nstesting.appspot.com) with M-Lab's sites properly
+mlab-ns URL (e.g. mlab-sandbox.appspot.com) with M-Lab's sites properly
 located.
 
 ## Gotchas

--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -22,25 +22,12 @@ steps:
   args:
    - ./build
 
-# Perform deployment in sandbox & staging.
-# TODO: eliminate use of "locate" for legacy service.
+# Perform deployment in sandbox & staging & mlab-ns.
 - name: gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif
   env:
     # Use cbif condition: only run these steps in one of these projects.
-    - PROJECT_IN=mlab-sandbox,mlab-staging
+    - PROJECT_IN=mlab-sandbox,mlab-staging,mlab-ns
   args:
     - python environment_bootstrap.py $PROJECT_ID
     - bash -c "cd server; gcloud --project $PROJECT_ID app deploy --promote app.yaml"
-    - sed -i -e 's/{{TARGET}}/locate/g' cron.yaml
-    - gcloud --project $PROJECT_ID app deploy --promote cron.yaml
-
-# Perform deployment in mlab-ns.
-- name: gcr.io/$PROJECT_ID/gcloud-jsonnet-cbif
-  env:
-    # Use cbif condition: only run these steps in mlab-ns project.
-    - PROJECT_IN=mlab-ns
-  args:
-    - python environment_bootstrap.py $PROJECT_ID
-    - bash -c "cd server; gcloud --project $PROJECT_ID app deploy --promote app.yaml"
-    - sed -i -e 's/{{TARGET}}/default/g' cron.yaml
     - gcloud --project $PROJECT_ID app deploy --promote cron.yaml

--- a/cron.yaml
+++ b/cron.yaml
@@ -2,7 +2,7 @@ cron:
 # Check for site status, run every minute.
 - description: Check sliver tools status
   url: /cron/check_status
-  target: {{TARGET}}
+  target: default
   schedule: every 1 minutes
 
 # Check for new sites, and for new and/or updated IP addresses, roundrobin information.
@@ -12,13 +12,13 @@ cron:
 # exist for the site before mlab-ns starts querying for it.
 - description: Check sites, update IP and roundrobin
   url: /cron/check_site
-  target: {{TARGET}}
+  target: default
   schedule: every day 15:05
 
 # Count client signatures found in memcache.
 - description: Count client signatures found in memcache.
   url: /cron/count_request_signatures
-  target: {{TARGET}}
+  target: default
   schedule: every 10 minutes
 
 # Update request signatures in memcache for mlab-ns.

--- a/server/app.yaml.mlab-sandbox
+++ b/server/app.yaml.mlab-sandbox
@@ -2,7 +2,6 @@ runtime: python27
 api_version: 1
 threadsafe: false
 instance_class: F4_1G
-service: locate
 
 handlers:
 

--- a/server/app.yaml.mlab-staging
+++ b/server/app.yaml.mlab-staging
@@ -2,7 +2,6 @@ runtime: python27
 api_version: 1
 threadsafe: false
 instance_class: F4_1G
-service: locate
 
 handlers:
 


### PR DESCRIPTION
This change removes use of service name "locate" by mlab-ns.

This change makes room for deploying the v2 "locate" service as a companion app engine service with the "default" service (mlab-ns).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/233)
<!-- Reviewable:end -->
