### PR TITLE
Updates production mlab-ns to use v2 hostnames.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu
+FROM ubuntu:18.04
 
 ENV PYTHONPATH $PYTHONPATH:/usr/local/google-cloud-sdk/platform/google_appengine
 # NOTE: the Cloud SDK component manager is disabled in this install, so

--- a/server/app.yaml.mlab-ns
+++ b/server/app.yaml.mlab-ns
@@ -60,4 +60,4 @@ env_variables:
   MACHINE_REGEX: "^mlab[1-3]$"
   SITE_REGEX: "^[a-z]{3}[0-9c]{2}$"
   LOCATIONS_URL: "https://siteinfo.mlab-oti.measurementlab.net/v1/sites/locations.json"
-  HOSTNAMES_URL: "https://siteinfo.mlab-oti.measurementlab.net/v1/sites/hostnames.json"
+  HOSTNAMES_URL: "https://siteinfo.mlab-oti.measurementlab.net/v2/sites/hostnames.json"


### PR DESCRIPTION
I believe that this change alone will be enough to trigger mlab-ns to start serving up v2 names.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/235)
<!-- Reviewable:end -->
