### PR TITLE
Checks for existence of existing entity using key_name, not fqdn

### DIFF
--- a/server/app.yaml.mlab-sandbox
+++ b/server/app.yaml.mlab-sandbox
@@ -64,7 +64,7 @@ env_variables:
   MACHINE_REGEX: "^mlab[1-4]$"
   SITE_REGEX: "^[a-z]{3}[0-9]t$"
   LOCATIONS_URL: "https://siteinfo.mlab-sandbox.measurementlab.net/v1/sites/locations.json"
-  HOSTNAMES_URL: "https://siteinfo.mlab-sandbox.measurementlab.net/v2/sites/hostnames.json"
+  HOSTNAMES_URL: "https://siteinfo.mlab-sandbox.measurementlab.net/v1/sites/hostnames.json"
 
 inbound_services:
 - warmup

--- a/server/app.yaml.mlab-sandbox
+++ b/server/app.yaml.mlab-sandbox
@@ -64,7 +64,7 @@ env_variables:
   MACHINE_REGEX: "^mlab[1-4]$"
   SITE_REGEX: "^[a-z]{3}[0-9]t$"
   LOCATIONS_URL: "https://siteinfo.mlab-sandbox.measurementlab.net/v1/sites/locations.json"
-  HOSTNAMES_URL: "https://siteinfo.mlab-sandbox.measurementlab.net/v1/sites/hostnames.json"
+  HOSTNAMES_URL: "https://siteinfo.mlab-sandbox.measurementlab.net/v2/sites/hostnames.json"
 
 inbound_services:
 - warmup

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -224,19 +224,14 @@ class IPUpdateHandler():
 
                 # If the sliver_tool already exists in the datastore, edit it.
                 # If not, add it to the datastore.
-                if len(slivertool) == 1:
+                if slivertool:
                     sliver_tool = slivertool[0]
-                elif len(slivertool) == 0:
+                else:
                     logging.info(
                         'For tool %s, fqdn %s is not in datastore.  Adding it.',
                         slice_tool.tool_id, fqdn)
                     sliver_tool = self.initialize_sliver_tool(slice_tool, site,
                                                               server_id, fqdn)
-                else:
-                    logging.error(
-                        'Error, or too many sliver_tools returned for {}:{}.'.format(
-                            slice_tool.tool_id, fqdn))
-                    continue
 
                 updated_sliver_tool = self.set_sliver_tool(
                     sliver_tool, ipv4, ipv6, site.roundrobin)

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -218,12 +218,12 @@ class IPUpdateHandler():
 
             for slice_tool in slice_tools:
                 # See if this sliver_tool already exists in the datastore.
-                slivertool = list(filter(
-                    lambda st: st.fqdn == fqdn and st.tool_id == slice_tool.tool_id,
-                    slivertools))
+                sliver_tool_id = model.get_sliver_tool_id(slice_tool.tool_id, slice_id,
+                                                          server_id, site_id)
+                slivertool = model.SliverTool.get_by_key_name(sliver_tool_id)
 
-                # Check to see if the sliver_tool already exists in the
-                # datastore. If not, add it to the datastore.
+                # If the sliver_tool already exists in the datastore, edit it.
+                # If not, add it to the datastore.
                 if len(slivertool) == 1:
                     sliver_tool = slivertool[0]
                 elif len(slivertool) == 0:

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -179,7 +179,6 @@ class IPUpdateHandler():
         # Fetch all data that we are going to need from the datastore up front.
         sites = list(model.Site.all().fetch(limit=None))
         tools = list(model.Tool.all().fetch(limit=None))
-        slivertools = list(model.SliverTool.all().fetch(limit=None))
 
         for row in rows:
             # Expected keys: "hostname,ipv4,ipv6" (ipv6 can be an empty string).
@@ -225,7 +224,7 @@ class IPUpdateHandler():
                 # If the sliver_tool already exists in the datastore, edit it.
                 # If not, add it to the datastore.
                 if slivertool:
-                    sliver_tool = slivertool[0]
+                    sliver_tool = slivertool
                 else:
                     logging.info(
                         'For tool %s, fqdn %s is not in datastore.  Adding it.',
@@ -234,7 +233,7 @@ class IPUpdateHandler():
                                                               server_id, fqdn)
 
                 updated_sliver_tool = self.set_sliver_tool(
-                    sliver_tool, ipv4, ipv6, site.roundrobin)
+                    sliver_tool, ipv4, ipv6, site.roundrobin, fqdn)
 
                 # Update datastore if the SliverTool got updated.
                 if updated_sliver_tool:
@@ -243,7 +242,7 @@ class IPUpdateHandler():
 
         return
 
-    def set_sliver_tool(self, sliver_tool, ipv4, ipv6, rr):
+    def set_sliver_tool(self, sliver_tool, ipv4, ipv6, rr, fqdn):
         updated = False
         if not ipv4:
             ipv4 = message.NO_IP_ADDRESS
@@ -258,6 +257,9 @@ class IPUpdateHandler():
             updated = True
         if not sliver_tool.roundrobin == rr:
             sliver_tool.roundrobin = rr
+            updated = True
+        if not sliver_tool.fqdn == fqdn:
+            sliver_tool.fqdn = fqdn
             updated = True
 
         if updated:

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -218,8 +218,8 @@ class IPUpdateHandler():
 
             for slice_tool in slice_tools:
                 # See if this sliver_tool already exists in the datastore.
-                sliver_tool_id = model.get_sliver_tool_id(slice_tool.tool_id, slice_id,
-                                                          server_id, site_id)
+                sliver_tool_id = model.get_sliver_tool_id(
+                    slice_tool.tool_id, slice_id, server_id, site_id)
                 slivertool = model.SliverTool.get_by_key_name(sliver_tool_id)
 
                 # If the sliver_tool already exists in the datastore, edit it.

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -220,8 +220,8 @@ class IPUpdateHandler():
                 # See if this sliver_tool already exists in the datastore.
                 sliver_tool_id = model.get_sliver_tool_id(
                     slice_tool.tool_id, slice_id, server_id, site_id)
-                slivertool = list(
-                    filter(lambda st: st.key == sliver_tool_id, slivertools))
+                slivertool = list(filter(lambda st: st.key == sliver_tool_id,
+                                         slivertools))
 
                 # If the sliver_tool already exists in the datastore, edit it.
                 # If not, add it to the datastore.
@@ -231,12 +231,12 @@ class IPUpdateHandler():
                     logging.info(
                         'For tool %s,  %s is not in datastore.  Adding it.',
                         slice_tool.tool_id, sliver_tool_id)
-                    sliver_tool = self.initialize_sliver_tool(
-                        slice_tool, site, server_id, fqdn)
+                    sliver_tool = self.initialize_sliver_tool(slice_tool, site,
+                                                              server_id, fqdn)
                 else:
                     logging.error(
-                        'Error, or too many sliver_tools returned for {}:{}.'.
-                        format(slice_tool.tool_id, sliver_tool_id))
+                        'Error, or too many sliver_tools returned for {}:{}.'.format(
+                            slice_tool.tool_id, sliver_tool_id))
                     continue
 
                 updated_sliver_tool = self.set_sliver_tool(


### PR DESCRIPTION
Currently, the `IPUpdateHandler()` checks for the existence of a `SliverTool` entity in datastore by comparing `fqdn` and `tool_id`. However, `fqdn` is not even part of the unique entity key_name. This PR changes the code to look for an existing entity using the (already existing) `key_name`.

The motivation for this is the transition from v1 to v2 names. In the current code, if the FQDN changes, the existing datastore record for a `SliverTool` is completely overwritten with a new record in which status defaults to "offline" for both IPv6 and IPv6.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/237)
<!-- Reviewable:end -->
