### PR TITLE
Migrate to the ndt5_client e2e check

### DIFF
--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -30,7 +30,7 @@ QUERIES = {
     'ndt': textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="ndt_raw"} OR
-            script_success{service="ndt_e2e"} OR
+            script_success{service="ndt5_client"} OR
             label_replace(((node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"} -
               node_filesystem_avail_bytes{cluster="platform-cluster", mountpoint="/cache/data"}) /
                 node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"}),
@@ -44,7 +44,7 @@ QUERIES = {
     'ndt_ipv6': textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="ndt_raw_ipv6"} OR
-            script_success{service="ndt_e2e"} OR
+            script_success{service="ndt5_client"} OR
             label_replace(((node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"} -
               node_filesystem_avail_bytes{cluster="platform-cluster", mountpoint="/cache/data"}) /
                 node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"}),
@@ -58,7 +58,7 @@ QUERIES = {
     'ndt_ssl': textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="ndt_ssl"} OR
-            script_success{service="ndt_e2e"} OR
+            script_success{service="ndt5_client"} OR
             label_replace(((node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"} -
               node_filesystem_avail_bytes{cluster="platform-cluster", mountpoint="/cache/data"}) /
                 node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"}),
@@ -72,7 +72,7 @@ QUERIES = {
     'ndt_ssl_ipv6': textwrap.dedent("""\
         min by (experiment, machine) (
             probe_success{service="ndt_ssl_ipv6"} OR
-            script_success{service="ndt_e2e"} OR
+            script_success{service="ndt5_client"} OR
             label_replace(((node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"} -
               node_filesystem_avail_bytes{cluster="platform-cluster", mountpoint="/cache/data"}) /
                 node_filesystem_size_bytes{cluster="platform-cluster", mountpoint="/cache/data"}),


### PR DESCRIPTION
Currently there are two script-exporter configurations targeting the m-lab platform. One running in a VM using tc rules to limit aggregate bandwidth, and another running in GKE using `ndt5-client -throttle` to limit bandwidth.

Over the last few days, the new script exporter identifies health nodes [at least as good as the ndt_e2e][link].

This change promotes the new e2e script exporter using ndt5_client to be the default used by mlab-ns.

This change adds a dependency on the locate service because the ndt5_client uses monitoring access tokens issued by the locate service.

[link]: https://prometheus.mlab-oti.measurementlab.net/graph?g0.range_input=2d&g0.end_input=2020-05-14%2013%3A58&g0.step_input=900&g0.expr=sum%20by(script)%20(script_success)&g0.tab=0

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/241)
<!-- Reviewable:end -->
