### PR TITLE
Undoes some v1->v2 transitional code

### DIFF
--- a/server/mlabns/tests/test_fqdn_rewrite.py
+++ b/server/mlabns/tests/test_fqdn_rewrite.py
@@ -16,12 +16,12 @@ class FqdnRewriteTest(unittest.TestCase):
         self.addCleanup(environ_patch.stop)
         environ_patch.start()
 
-    def testAfAgnosticNdtPlaintextFqdn(self):
+    def testAfAgnosticNdtFqdn(self):
         """When there is no AF and tool is not NDT-SSL, don't rewrite."""
         fqdn = 'ndt-iupui-mlab4-lga06.mlab-staging.measurement-lab.org'
         self.assertEqual(fqdn, fqdn_rewrite.rewrite(fqdn, None, 'ndt'))
 
-    def testIPv4NdtPlaintextFqdn(self):
+    def testIPv4NdtFqdn(self):
         """Add a v4 annotation for v4-specific requests."""
         fqdn_original = 'ndt-iupui-mlab4-lga06.mlab-staging.measurement-lab.org'
         fqdn_expected = 'ndt-iupui-mlab4v4-lga06.mlab-staging.measurement-lab.org'
@@ -29,7 +29,7 @@ class FqdnRewriteTest(unittest.TestCase):
                                            message.ADDRESS_FAMILY_IPv4, 'ndt')
         self.assertEqual(fqdn_expected, fqdn_actual)
 
-    def testIPv4WehePlaintextFqdn(self):
+    def testIPv4WeheFqdn(self):
         """Add a v4 annotation for v4-specific requests."""
         fqdn_original = 'wehe-mlab4-lga06.mlab-staging.measurement-lab.org'
         fqdn_expected = 'wehe-mlab4v4-lga06.mlab-staging.measurement-lab.org'
@@ -37,7 +37,7 @@ class FqdnRewriteTest(unittest.TestCase):
                                            message.ADDRESS_FAMILY_IPv4, 'ndt')
         self.assertEqual(fqdn_expected, fqdn_actual)
 
-    def testIPv6NdtPlaintextFqdn(self):
+    def testIPv6NdtFqdn(self):
         """Add a v6 annotation for v6-specific requests."""
         fqdn_original = 'ndt-iupui-mlab4-lga06.mlab-staging.measurement-lab.org'
         fqdn_expected = 'ndt-iupui-mlab4v6-lga06.mlab-staging.measurement-lab.org'
@@ -45,7 +45,7 @@ class FqdnRewriteTest(unittest.TestCase):
                                            message.ADDRESS_FAMILY_IPv6, 'ndt')
         self.assertEqual(fqdn_expected, fqdn_actual)
 
-    def testIPv4WehePlaintextFqdnFlat(self):
+    def testIPv4WeheFqdnFlat(self):
         """Add a v4 annotation for v4-specific requests."""
         fqdn_original = 'wehe-mlab4-lga0t.mlab-sandbox.measurement-lab.org'
         fqdn_expected = 'wehe-mlab4v4-lga0t.mlab-sandbox.measurement-lab.org'

--- a/server/mlabns/tests/test_fqdn_rewrite.py
+++ b/server/mlabns/tests/test_fqdn_rewrite.py
@@ -18,83 +18,32 @@ class FqdnRewriteTest(unittest.TestCase):
 
     def testAfAgnosticNdtPlaintextFqdn(self):
         """When there is no AF and tool is not NDT-SSL, don't rewrite."""
-        fqdn = 'ndt.iupui.mlab4.lga06.measurement-lab.org'
+        fqdn = 'ndt-iupui-mlab4-lga06.mlab-staging.measurement-lab.org'
         self.assertEqual(fqdn, fqdn_rewrite.rewrite(fqdn, None, 'ndt'))
 
     def testIPv4NdtPlaintextFqdn(self):
         """Add a v4 annotation for v4-specific requests."""
-        fqdn_original = 'ndt.iupui.mlab4.lga06.measurement-lab.org'
-        fqdn_expected = 'ndt.iupui.mlab4v4.lga06.measurement-lab.org'
+        fqdn_original = 'ndt-iupui-mlab4-lga06.mlab-staging.measurement-lab.org'
+        fqdn_expected = 'ndt-iupui-mlab4v4-lga06.mlab-staging.measurement-lab.org'
         fqdn_actual = fqdn_rewrite.rewrite(fqdn_original,
                                            message.ADDRESS_FAMILY_IPv4, 'ndt')
         self.assertEqual(fqdn_expected, fqdn_actual)
 
     def testIPv4WehePlaintextFqdn(self):
         """Add a v4 annotation for v4-specific requests."""
-        fqdn_original = 'wehe.mlab4.lga06.measurement-lab.org'
-        fqdn_expected = 'wehe.mlab4v4.lga06.measurement-lab.org'
+        fqdn_original = 'wehe-mlab4-lga06.mlab-staging.measurement-lab.org'
+        fqdn_expected = 'wehe-mlab4v4-lga06.mlab-staging.measurement-lab.org'
         fqdn_actual = fqdn_rewrite.rewrite(fqdn_original,
                                            message.ADDRESS_FAMILY_IPv4, 'ndt')
         self.assertEqual(fqdn_expected, fqdn_actual)
 
     def testIPv6NdtPlaintextFqdn(self):
         """Add a v6 annotation for v6-specific requests."""
-        fqdn_original = 'ndt.iupui.mlab4.lga06.measurement-lab.org'
-        fqdn_expected = 'ndt.iupui.mlab4v6.lga06.measurement-lab.org'
+        fqdn_original = 'ndt-iupui-mlab4-lga06.mlab-staging.measurement-lab.org'
+        fqdn_expected = 'ndt-iupui-mlab4v6-lga06.mlab-staging.measurement-lab.org'
         fqdn_actual = fqdn_rewrite.rewrite(fqdn_original,
                                            message.ADDRESS_FAMILY_IPv6, 'ndt')
         self.assertEqual(fqdn_expected, fqdn_actual)
-
-    def testAfAgnosticNdtSslFqdn(self):
-        """Convert dots to dashes, but omit AF annotation for NDT-SSL."""
-        fqdn_original = 'ndt.iupui.mlab4.lga06.measurement-lab.org'
-        fqdn_expected = 'ndt-iupui-mlab4-lga06.measurement-lab.org'
-        fqdn_actual = fqdn_rewrite.rewrite(fqdn_original, None, 'ndt_ssl')
-        self.assertEqual(fqdn_expected, fqdn_actual)
-
-    def testIPv4NdtSslFqdn(self):
-        """Add a v4 annotation and rewrite dots to dashes for NDT-SSL."""
-        fqdn_original = 'ndt.iupui.mlab4.lga06.measurement-lab.org'
-        fqdn_expected = 'ndt-iupui-mlab4v4-lga06.measurement-lab.org'
-        fqdn_actual = fqdn_rewrite.rewrite(
-            fqdn_original, message.ADDRESS_FAMILY_IPv4, 'ndt_ssl')
-        self.assertEqual(fqdn_expected, fqdn_actual)
-
-    def testIPv6NdtSslFqdn(self):
-        """Add a v6 annotation and rewrite dots to dashes for NDT-SSL."""
-        fqdn_original = 'ndt.iupui.mlab4.lga06.measurement-lab.org'
-        fqdn_expected = 'ndt-iupui-mlab4v6-lga06.measurement-lab.org'
-        fqdn_actual = fqdn_rewrite.rewrite(
-            fqdn_original, message.ADDRESS_FAMILY_IPv6, 'ndt_ssl')
-        self.assertEqual(fqdn_expected, fqdn_actual)
-
-    def testAfAgnosticNdt7Fqdn(self):
-        """Convert dots to dashes, but omit AF annotation for ndt7."""
-        fqdn_original = 'ndt.iupui.mlab4.lga06.measurement-lab.org'
-        fqdn_expected = 'ndt-iupui-mlab4-lga06.measurement-lab.org'
-        fqdn_actual = fqdn_rewrite.rewrite(fqdn_original, None, 'ndt7')
-        self.assertEqual(fqdn_expected, fqdn_actual)
-
-    def testIPv4Ndt7Fqdn(self):
-        """Add a v4 annotation and rewrite dots to dashes for ndt7."""
-        fqdn_original = 'ndt.iupui.mlab4.lga06.measurement-lab.org'
-        fqdn_expected = 'ndt-iupui-mlab4v4-lga06.measurement-lab.org'
-        fqdn_actual = fqdn_rewrite.rewrite(fqdn_original,
-                                           message.ADDRESS_FAMILY_IPv4, 'ndt7')
-        self.assertEqual(fqdn_expected, fqdn_actual)
-
-    def testIPv6Ndt7Fqdn(self):
-        """Add a v6 annotation and rewrite dots to dashes for ndt7."""
-        fqdn_original = 'ndt.iupui.mlab4.lga06.measurement-lab.org'
-        fqdn_expected = 'ndt-iupui-mlab4v6-lga06.measurement-lab.org'
-        fqdn_actual = fqdn_rewrite.rewrite(fqdn_original,
-                                           message.ADDRESS_FAMILY_IPv6, 'ndt7')
-        self.assertEqual(fqdn_expected, fqdn_actual)
-
-    def testIPv4FlatName(self):
-        """Do nothing since this name is already flattened."""
-        fqdn = 'ndt-iupui-mlab4-lga0t.mlab-sandbox.measurement-lab.org'
-        self.assertEqual(fqdn, fqdn_rewrite.rewrite(fqdn, None, 'ndt'))
 
     def testIPv4WehePlaintextFqdnFlat(self):
         """Add a v4 annotation for v4-specific requests."""

--- a/server/mlabns/tests/test_prometheus_status.py
+++ b/server/mlabns/tests/test_prometheus_status.py
@@ -14,12 +14,13 @@ class ParseSliverToolStatusTest(unittest2.TestCase):
         status = {
             "metric": {
                 "experiment": "ndt.iupui",
-                "machine": "mlab1.abc01.measurement-lab.org"
+                "machine": "mlab1-abc01.mlab-oti.measurement-lab.org"
             },
             "value": [1522782427.81, "1"]
         }
-        expected_parsed_status = ('ndt.iupui.mlab1.abc01.measurement-lab.org',
-                                  '1', constants.PROMETHEUS_TOOL_EXTRA)
+        expected_parsed_status = (
+            'ndt-iupui-mlab1-abc01.mlab-oti.measurement-lab.org', '1',
+            constants.PROMETHEUS_TOOL_EXTRA)
         actual_parsed_status = prometheus_status.parse_sliver_tool_status(
             status)
 
@@ -113,12 +114,12 @@ class StatusUpdateHandlerTest(unittest2.TestCase):
                 "result": [
                     { "metric": {
                           "experiment": "mock",
-                          "machine": "mlab1.xyz01.measurement-lab.org" },
+                          "machine": "mlab1-xyz01.mlab-oti.measurement-lab.org" },
                       "value": [1522782427.81, "1"]
                     },
                     { "metric": {
                           "experiment": "mock",
-                          "machine": "mlab2.xyz01.measurement-lab.org" },
+                          "machine": "mlab2-xyz01.mlab-oti.measurement-lab.org" },
                       "value": [1522773427.51, "0"]
                     }
                 ]
@@ -127,18 +128,18 @@ class StatusUpdateHandlerTest(unittest2.TestCase):
         mock_open.return_value = self.mock_response
 
         mock_parse_sliver_tool_status.side_effect = [
-            ('mock.mlab1.xyz01.measurement-lab.org', '1',
+            ('mock-mlab1-xyz01.mlab-oti.measurement-lab.org', '1',
              constants.PROMETHEUS_TOOL_EXTRA),
-            ('mock.mlab2.xyz01.measurement-lab.org', '0',
+            ('mock-mlab2-xyz01.mlab-oti.measurement-lab.org', '0',
              constants.PROMETHEUS_TOOL_EXTRA)
         ]
 
         expected_status = {
-            'mock.mlab1.xyz01.measurement-lab.org': {
+            'mock-mlab1-xyz01.mlab-oti.measurement-lab.org': {
                 'status': message.STATUS_ONLINE,
                 'tool_extra': constants.PROMETHEUS_TOOL_EXTRA
             },
-            'mock.mlab2.xyz01.measurement-lab.org': {
+            'mock-mlab2-xyz01.mlab-oti.measurement-lab.org': {
                 'status': message.STATUS_OFFLINE,
                 'tool_extra': constants.PROMETHEUS_TOOL_EXTRA
             }

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -214,19 +214,12 @@ def parse_sliver_tool_status(status):
         raise PrometheusStatusUnparseableError(
             'Prometheus status format unrecognized: %s' % status)
 
-    experiment = status['metric']['experiment']
+    experiment = status['metric']['experiment'].replace('.', '-')
     machine = status['metric']['machine']
-    join_char = '.'
-
-    # If the machine/site part of the machine name appear to be a v2 hostname,
-    # then flatten the experiment field, and join with a dash instad of a dot.
-    if re.match('^mlab[1-4]-', machine):
-        experiment = experiment.replace('.', '-')
-        join_char = '-'
 
     # Joins the experiment name with the machine name to form the FQDN of the
     # experiment.
-    sliver_fqdn = experiment + join_char + machine
+    sliver_fqdn = experiment + '-' + machine
 
     # 'status' is a list with two items. The first item ([0]) is a timestamp
     # marking the Prometheus evaluation time. The second, which is the one we

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -1,6 +1,5 @@
 import json
 import logging
-import re
 import textwrap
 import urllib
 import urllib2


### PR DESCRIPTION
Now that the platform is 100% v2 node names, we no longer need transitional logic in our code. The PR removes two pieces of transitional logic and update their respective unit tests to take this into account.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/242)
<!-- Reviewable:end -->
