### PR TITLE
Add /v2/platform/* dispatch rules

### DIFF
--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -4,6 +4,8 @@ dispatch:
 # Route /v2/ requests to the locate service.
 - service: locate
   url: "*/v2beta1/*"
+- service: locate-platform
+  url: "*/v2/platform/*"
 - service: locate
   url: "*/v2/*"
 # All other requests are routed to their default target.


### PR DESCRIPTION
This change updates the dispatch.yml rules that impact how `/v2/*` requests are routed to the locate and locate-platform services. This change is step 3 of https://github.com/m-lab/dev-tracker/issues/600

Currently monitoring requests issued to `/v2/platform/monitoring` are actually routed to the "locate" service. This change ensures that those requests are delivered to the locate-platform service.

This change is necessary to allow us to manage the user-visible APIs in the locate service using Cloud Endpoints (e.g. /v2/nearest), without exposing users to extraneous API calls needed to manage the platform (e.g. monitoring).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/244)
<!-- Reviewable:end -->
