### PR TITLE
Lowers probability for HND01 to 0.1 to reduce discards.

### DIFF
--- a/server/mlabns/util/resolver.py
+++ b/server/mlabns/util/resolver.py
@@ -58,7 +58,7 @@ class AllResolver(ResolverBase):
 # selecting this site. The default value is 1.0.
 site_keep_probability = {
     'bom01': 0.5,
-    'hnd01': 0.2,  # 0.2
+    'hnd01': 0.1,  # 0.1
     'lga1t': 0.5,
     'lis01': 0.5,
     'lju01': 0.5,


### PR DESCRIPTION
`DataQuality_TooManyNdtS2cTestsWithDiscards` alerts are firing for HND01. This PR reduces the probability that mlab-ns will send a user to HND01, which should lower the overall traffic, thereby reducing discards at this 1g site.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/246)
<!-- Reviewable:end -->
