### PR TITLE
Stops updating datastore when too many services are down

### DIFF
--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -372,6 +372,9 @@ class StatusUpdateHandler(webapp.RequestHandler):
                             if not self.is_slice_status_okay(
                                     slice_status, slice_info.tool_id,
                                     slice_info.address_family):
+                                logging.error(
+                                    'Ignorning monitoring data for: %s',
+                                    slice_info.tool_id)
                                 continue
                     else:
                         logging.error(
@@ -520,6 +523,7 @@ class StatusUpdateHandler(webapp.RequestHandler):
         percentage_online = online_slivers / len(slice_status)
 
         if percentage_online < threshold:
+            logging.error('Too few slivers online: %f', percentage_online)
             return False
         else:
             return True

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -369,9 +369,9 @@ class StatusUpdateHandler(webapp.RequestHandler):
                         # datastore. This prevents a monitoring bug/issue from
                         # causing all sliver tools to be marked as down.
                         if slice_info.tool_id.startswith('ndt'):
-                            if not self.is_slice_status_okay(slice_status,
-                                                             slice_info.tool_id,
-                                                             slice_info.address_family):
+                            if not self.is_slice_status_okay(
+                                    slice_status, slice_info.tool_id,
+                                    slice_info.address_family):
                                 continue
                     else:
                         logging.error(

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -516,13 +516,14 @@ class StatusUpdateHandler(webapp.RequestHandler):
             threshold = 0.75
 
         online_slivers = 0
-        logging.info('STATUS: len(slice_status): %d', len(slice_status))
         for sliver_tool in slice_status:
-            logging.info('STATUS: %s = %s', sliver_tool,
-                         slice_status[sliver_tool]['status'])
             if slice_status[sliver_tool]['status'] == message.STATUS_ONLINE:
                 online_slivers = online_slivers + 1
+                logging.info('STATUS: incrementing online_slivers: %d',
+                             online_slivers)
 
+        logging.info('STATUS: online_slivers: %d, len(slice_status): %d',
+                     online_slivers, len(slice_status))
         percentage_online = online_slivers / len(slice_status)
 
         if percentage_online < threshold:

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -518,9 +518,9 @@ class StatusUpdateHandler(webapp.RequestHandler):
         online_slivers = 0
         logging.info('STATUS: len(slice_status): %d', len(slice_status))
         for sliver_tool in slice_status:
+            logging.info('STATUS: %s = %s', sliver_tool,
+                         slice_status[sliver_tool]['status'])
             if slice_status[sliver_tool]['status'] == message.STATUS_ONLINE:
-                logging.info('STATUS: %s = %s', sliver_tool,
-                              slice_status[sliver_tool]['status'])
                 online_slivers = online_slivers + 1
 
         percentage_online = online_slivers / len(slice_status)

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -363,6 +363,16 @@ class StatusUpdateHandler(webapp.RequestHandler):
                             continue
                         slice_status = prometheus_status.get_slice_status(
                             slice_info.slice_url, prometheus_opener)
+                        # For NDT, if too large a percentage of sliver tools
+                        # are down, then we assume that there is some sort of
+                        # monitoring error and we refuse to update the
+                        # datastore. This prevents a monitoring bug/issue from
+                        # causing all sliver tools to be marked as down.
+                        if slice_info.tool_id.startswith('ndt'):
+                            if not self.is_slice_status_okay(slice_status,
+                                                             slice_info.tool_id,
+                                                             slice_info.address_family):
+                            continue
                     else:
                         logging.error(
                             'Prometheus config unavailable. Skipping %s%s',
@@ -483,6 +493,36 @@ class StatusUpdateHandler(webapp.RequestHandler):
                                 updated_sliver_tools,
                                 namespace=constants.MEMCACHE_NAMESPACE_TOOLS):
                 logging.error('Failed to update sliver status in memcache.')
+
+    def is_slice_status_okay(self, slice_status, tool_id, family):
+        """Determines if percentage of online sliver tools is too low
+
+        Args:
+            slice_status: A dict that contains the status of the
+                slivers in the slice {key=fqdn, status:online|offline}
+            tool_id: A string representing the fqdn that resolves
+                to an IP address.
+            family: Address family to update.
+
+        Returns:
+            bool: whether slice status is below minimum threshold
+        """
+        if family == '_ipv6':
+            threshold = 0.5
+        else:
+            threshold = 0.75
+
+        online_slivers = 0
+        for sliver_tool in slice_status:
+            if sliver_tool.status == message.STATUS_ONLINE:
+                online_slivers = online_slivers + 1
+
+        percentage_online = online_slivers / len(slice_status)
+
+        if percentage_online < threshold:
+            return False
+        else:
+            return True
 
 
 class ReloadMaxmindDb(webapp.RequestHandler):

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -372,7 +372,7 @@ class StatusUpdateHandler(webapp.RequestHandler):
                             if not self.is_slice_status_okay(slice_status,
                                                              slice_info.tool_id,
                                                              slice_info.address_family):
-                            continue
+                                continue
                     else:
                         logging.error(
                             'Prometheus config unavailable. Skipping %s%s',

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -517,7 +517,7 @@ class StatusUpdateHandler(webapp.RequestHandler):
 
         online_slivers = 0
         for sliver_tool in slice_status:
-            if sliver_tool.status == message.STATUS_ONLINE:
+            if slice_status[sliver_tool]['status'] == message.STATUS_ONLINE:
                 online_slivers = online_slivers + 1
 
         percentage_online = online_slivers / len(slice_status)

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -519,7 +519,7 @@ class StatusUpdateHandler(webapp.RequestHandler):
         logging.info('STATUS: len(slice_status): %d', len(slice_status))
         for sliver_tool in slice_status:
             if slice_status[sliver_tool]['status'] == message.STATUS_ONLINE:
-                loggging.info('STATUS: %s = %s', sliver_tool,
+                logging.info('STATUS: %s = %s', sliver_tool,
                               slice_status[sliver_tool]['status'])
                 online_slivers = online_slivers + 1
 

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -516,14 +516,18 @@ class StatusUpdateHandler(webapp.RequestHandler):
             threshold = 0.75
 
         online_slivers = 0
+        logging.info('STATUS: len(slice_status): %d', len(slice_status))
         for sliver_tool in slice_status:
             if slice_status[sliver_tool]['status'] == message.STATUS_ONLINE:
+                loggging.info('STATUS: %s = %s', sliver_tool,
+                              slice_status[sliver_tool]['status'])
                 online_slivers = online_slivers + 1
 
         percentage_online = online_slivers / len(slice_status)
 
         if percentage_online < threshold:
-            logging.error('Too few slivers online: %f', percentage_online)
+            logging.error('Too few %s slivers online. Threshold %f. Actual %f',
+                          tool_id, threshold, percentage_online)
             return False
         else:
             return True

--- a/server/mlabns/handlers/update.py
+++ b/server/mlabns/handlers/update.py
@@ -363,19 +363,17 @@ class StatusUpdateHandler(webapp.RequestHandler):
                             continue
                         slice_status = prometheus_status.get_slice_status(
                             slice_info.slice_url, prometheus_opener)
-                        # For NDT, if too large a percentage of sliver tools
-                        # are down, then we assume that there is some sort of
-                        # monitoring error and we refuse to update the
-                        # datastore. This prevents a monitoring bug/issue from
-                        # causing all sliver tools to be marked as down.
-                        if slice_info.tool_id.startswith('ndt'):
-                            if not self.is_slice_status_okay(
-                                    slice_status, slice_info.tool_id,
-                                    slice_info.address_family):
-                                logging.error(
-                                    'Ignorning monitoring data for: %s',
-                                    slice_info.tool_id)
-                                continue
+                        # If too large a percentage of sliver tools are down,
+                        # then we assume that there is some sort of monitoring
+                        # error and we refuse to update the datastore. This
+                        # prevents a monitoring bug/issue from causing all
+                        # sliver tools to be marked as down.
+                        if not self.is_slice_status_okay(
+                                slice_status, slice_info.tool_id,
+                                slice_info.address_family):
+                            logging.error('Ignorning monitoring data for: %s',
+                                          slice_info.tool_id)
+                            continue
                     else:
                         logging.error(
                             'Prometheus config unavailable. Skipping %s%s',
@@ -519,12 +517,8 @@ class StatusUpdateHandler(webapp.RequestHandler):
         for sliver_tool in slice_status:
             if slice_status[sliver_tool]['status'] == message.STATUS_ONLINE:
                 online_slivers = online_slivers + 1
-                logging.info('STATUS: incrementing online_slivers: %d',
-                             online_slivers)
 
-        logging.info('STATUS: online_slivers: %d, len(slice_status): %d',
-                     online_slivers, len(slice_status))
-        percentage_online = online_slivers / len(slice_status)
+        percentage_online = float(online_slivers) / len(slice_status)
 
         if percentage_online < threshold:
             logging.error('Too few %s slivers online. Threshold %f. Actual %f',


### PR DESCRIPTION
This small PR introduces a check to be sure that more than a certain percentage of services are reported as online before using monitoring data to update service state. This PR is intended to resolve https://github.com/m-lab/mlab-ns/issues/243.

We currently have [numerous NDT-related alerts](https://github.com/m-lab/prometheus-support/blob/master/config/federation/prometheus/alerts.yml#L213) that will notify us when less than 90% of NDT services are reported as online for IPv4 (<75% for IPv6). The statically configured thresholds in the PR are well below the alert thresholds, meaning that we will receive alerts about a problem before mlab-ns starts disregarding monitoring results and serving stale data.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/251)
<!-- Reviewable:end -->
