### PR TITLE
Adds a prometheus status query for Wehe

### DIFF
--- a/server/mlabns/conf/tools.csv
+++ b/server/mlabns/conf/tools.csv
@@ -4,3 +4,4 @@ ndt_ssl,iupui_ndt,,False,prometheus
 ndt7,iupui_ndt,,False,prometheus
 mobiperf,michigan_1,,False,prometheus
 neubot,mlab_neubot,80,False,prometheus
+wehe,wehe,,False,prometheus

--- a/server/mlabns/util/prometheus_status.py
+++ b/server/mlabns/util/prometheus_status.py
@@ -126,6 +126,14 @@ QUERIES = {
             label_replace(gmx_machine_maintenance, "experiment", "neubot.mlab", "", "") != bool 1
         )
         """),
+    'wehe': textwrap.dedent("""\
+        min by (experiment, machine) (
+            script_success{service="wehe_client"} OR
+            label_replace(kube_node_spec_taint{cluster="platform-cluster", key="lame-duck"},
+              "experiment", "wehe", "", "") != bool 1 OR
+            label_replace(gmx_machine_maintenance, "experiment", "wehe", "", "") != bool 1
+        )
+        """),
 }
 
 


### PR DESCRIPTION
This PR adds a new Prometheus status query for Wehe. In addition to this PR, it is necessary to manually add a new `Tool` in GCD for wehe in each GCP project.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/252)
<!-- Reviewable:end -->
