### PR TITLE
Removes TNR01 from site_keep_probability. It is now a 10g site

### DIFF
--- a/server/mlabns/util/resolver.py
+++ b/server/mlabns/util/resolver.py
@@ -62,7 +62,6 @@ site_keep_probability = {
     'lga1t': 0.5,
     'lis01': 0.5,
     'lju01': 0.5,
-    'tnr01': 0.5,
     'tun01': 0.5,
     'vie01': 0.5,
     'yqm01': 0.5,


### PR DESCRIPTION


<!-- Reviewable:start -->
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/253)
<!-- Reviewable:end -->
