### PR TITLE
Enables warmup handling in production (mlab-ns)

### DIFF
--- a/server/app.yaml.mlab-ns
+++ b/server/app.yaml.mlab-ns
@@ -37,6 +37,10 @@ handlers:
 - url: /.*
   script: main.app
 
+- url: /_ah/warmup
+  script: main.py
+  login: admin
+
 builtins:
 - appstats: on
 - deferred: on
@@ -61,3 +65,7 @@ env_variables:
   SITE_REGEX: "^[a-z]{3}[0-9c]{2}$"
   LOCATIONS_URL: "https://siteinfo.mlab-oti.measurementlab.net/v1/sites/locations.json"
   HOSTNAMES_URL: "https://siteinfo.mlab-oti.measurementlab.net/v2/sites/hostnames.json"
+
+inbound_services:
+- warmup
+


### PR DESCRIPTION
Warmup handling was enabled and handled in sandbox and staging
AppEngine configurations, but not in production (for unknown reasons.
oversight?). This enables it and configures the handler.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/255)
<!-- Reviewable:end -->
