### PR TITLE
Reduces probability for new virtual sites

### DIFF
--- a/server/mlabns/util/resolver.py
+++ b/server/mlabns/util/resolver.py
@@ -58,20 +58,20 @@ class AllResolver(ResolverBase):
 # selecting this site. The default value is 1.0.
 site_keep_probability = {
     'bom01': 0.5,
-    'bru06': 0.01, # virtual site
-    'cgk01': 0.01, # virtual site
-    'fra07': 0.01, # virtual site
+    'bru06': 0.01,  # virtual site
+    'cgk01': 0.01,  # virtual site
+    'fra07': 0.01,  # virtual site
     'hnd01': 0.05,  # 0.05
-    'iad07': 0.01, # virtual site
-    'lax07': 0.01, # virtual site
+    'iad07': 0.01,  # virtual site
+    'lax07': 0.01,  # virtual site
     'lga1t': 0.5,
-    'lhr09': 0.01, # virtual site
+    'lhr09': 0.01,  # virtual site
     'lis01': 0.5,
     'lju01': 0.5,
-    'ord07': 0.01, # virtual site
-    'sea09': 0.01, # virtual site
-    'sin02': 0.01, # virtual site
-    'tpe02': 0.01, # virtual site
+    'ord07': 0.01,  # virtual site
+    'sea09': 0.01,  # virtual site
+    'sin02': 0.01,  # virtual site
+    'tpe02': 0.01,  # virtual site
     'tun01': 0.5,
     'vie01': 0.5,
     'yqm01': 0.5,

--- a/server/mlabns/util/resolver.py
+++ b/server/mlabns/util/resolver.py
@@ -58,10 +58,20 @@ class AllResolver(ResolverBase):
 # selecting this site. The default value is 1.0.
 site_keep_probability = {
     'bom01': 0.5,
+    'bru06': 0.01, # virtual site
+    'cgk01': 0.01, # virtual site
+    'fra07': 0.01, # virtual site
     'hnd01': 0.05,  # 0.05
+    'iad07': 0.01, # virtual site
+    'lax07': 0.01, # virtual site
     'lga1t': 0.5,
+    'lhr09': 0.01, # virtual site
     'lis01': 0.5,
     'lju01': 0.5,
+    'ord07': 0.01, # virtual site
+    'sea09': 0.01, # virtual site
+    'sin02': 0.01, # virtual site
+    'tpe02': 0.01, # virtual site
     'tun01': 0.5,
     'vie01': 0.5,
     'yqm01': 0.5,

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -3,12 +3,12 @@ geoip2
 maxminddb==1.5.4
 GoogleAppEngineCloudStorageClient
 jinja2
+lazy-object-proxy==1.6.0
 mock==2.0.0
 pillow
 pyflakes==1.2.3
 pylint==1.5.6
 pyyaml
-setuptools-scm==5.0.2
 unittest2
 webob
 yapf==0.10.0

--- a/test_requirements.txt
+++ b/test_requirements.txt
@@ -8,6 +8,7 @@ pillow
 pyflakes==1.2.3
 pylint==1.5.6
 pyyaml
+setuptools-scm==5.0.2
 unittest2
 webob
 yapf==0.10.0


### PR DESCRIPTION
This PR adds the 10 new production virtual sites to the `site_keep_probability` dict, all with a probability of 0.01. This will allow some traffic to those sites, while allowing us to inspect the data as part of a "fast" canary process.

This PR also adds `lazy-object-proxy==1.6.0` to test_requirements.txt to resolve [a build breakage](https://console.cloud.google.com/cloud-build/builds;region=global/f534c6f9-ec75-4202-9c09-3078451fd029?project=mlab-sandbox).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/257)
<!-- Reviewable:end -->
