### PR TITLE
Increase cloud sites to 10%

### DIFF
--- a/server/mlabns/util/resolver.py
+++ b/server/mlabns/util/resolver.py
@@ -1,10 +1,8 @@
 import logging
 import random
 
-from mlabns.db import sliver_tool_fetcher
-from mlabns.util import distance
-from mlabns.util import message
-from mlabns.db import client_signature_fetcher
+from mlabns.db import client_signature_fetcher, sliver_tool_fetcher
+from mlabns.util import distance, message
 
 
 def _tool_properties_from_query(query):
@@ -58,20 +56,20 @@ class AllResolver(ResolverBase):
 # selecting this site. The default value is 1.0.
 site_keep_probability = {
     'bom01': 0.5,
-    'bru06': 0.01,  # virtual site
-    'cgk01': 0.01,  # virtual site
-    'fra07': 0.01,  # virtual site
+    'bru06': 0.1,  # virtual site
+    'cgk01': 0.1,  # virtual site
+    'fra07': 0.1,  # virtual site
     'hnd01': 0.05,  # 0.05
-    'iad07': 0.01,  # virtual site
-    'lax07': 0.01,  # virtual site
+    'iad07': 0.1,  # virtual site
+    'lax07': 0.1,  # virtual site
     'lga1t': 0.5,
-    'lhr09': 0.01,  # virtual site
+    'lhr09': 0.1,  # virtual site
     'lis01': 0.5,
     'lju01': 0.5,
-    'ord07': 0.01,  # virtual site
-    'sea09': 0.01,  # virtual site
-    'sin02': 0.01,  # virtual site
-    'tpe02': 0.01,  # virtual site
+    'ord07': 0.1,  # virtual site
+    'sea09': 0.1,  # virtual site
+    'sin02': 0.1,  # virtual site
+    'tpe02': 0.1,  # virtual site
     'tun01': 0.5,
     'vie01': 0.5,
     'yqm01': 0.5,


### PR DESCRIPTION
This change updates the cloud probabilities to 10%.

This change is to facilitate additional calibration analysis for ndt5 and ndt7 measurements collected on cloud nodes.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/258)
<!-- Reviewable:end -->
