### PR TITLE
Remove /v2/platform/* dispatch rule

### DIFF
--- a/dispatch.yaml
+++ b/dispatch.yaml
@@ -4,8 +4,6 @@ dispatch:
 # Route /v2/ requests to the locate service.
 - service: locate
   url: "*/v2beta1/*"
-- service: locate-platform
-  url: "*/v2/platform/*"
 - service: locate
   url: "*/v2/*"
 # All other requests are routed to their default target.


### PR DESCRIPTION
This is part of https://github.com/m-lab/prometheus-support/issues/912.

Original PR where the rule was added: https://github.com/m-lab/mlab-ns/pull/244.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/259)
<!-- Reviewable:end -->
