### PR TITLE
Removes BOM03 from site_keep_probability

### DIFF
--- a/server/mlabns/util/resolver.py
+++ b/server/mlabns/util/resolver.py
@@ -57,7 +57,6 @@ class AllResolver(ResolverBase):
 site_keep_probability = {
     'ams10': 0.1,  # virtual site
     'bom01': 0.5,
-    'bom03': 0.1,  # virtual site
     'bru06': 0.1,  # virtual site
     'cgk01': 0.1,  # virtual site
     'chs01': 0.1,  # virtual site


### PR DESCRIPTION
We want virtual nodes at BOM03 to receive the same probability as any physical machines. This could have been achieved, I believe, by setting the site_keep_probability for bom03 to 1.0. Easier was to just remove it from site_keep_probability altogether.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/262)
<!-- Reviewable:end -->
