### PR TITLE
Add bom02 to 50%, part of cloud metro trial

### DIFF
--- a/server/mlabns/util/resolver.py
+++ b/server/mlabns/util/resolver.py
@@ -56,6 +56,7 @@ class AllResolver(ResolverBase):
 # selecting this site. The default value is 1.0.
 site_keep_probability = {
     'bom01': 0.5,
+    'bom02': 0.5,
     'bru06': 0.1,  # virtual site
     'cgk01': 0.1,  # virtual site
     'fra07': 0.1,  # virtual site


### PR DESCRIPTION
The next steps for the cloud metro trial is to reduce bom02 to 50% probability. This change adds bom02 (previously 100%) to the list of static probabiities in mlab-ns.

Part of:
* https://github.com/m-lab/ops-tracker/issues/1665

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/267)
<!-- Reviewable:end -->
