### PR TITLE
Removes sites  gru05/hnd06 from site_keep_probability

### DIFF
--- a/server/mlabns/util/resolver.py
+++ b/server/mlabns/util/resolver.py
@@ -65,11 +65,9 @@ site_keep_probability = {
     'del03': 0.1,  # virtual site
     'dfw09': 0.1,  # virtual site
     'fra07': 0.1,  # virtual site
-    'gru05': 0.1,  # virtual site
     'hel01': 0.1,  # virtual site
     'hkg04': 0.1,  # virtual site
     'hnd01': 0.05,  # 0.05
-    'hnd06': 0.1,  # virtual site
     'iad07': 0.1,  # virtual site
     'icn01': 0.1,  # virtual site
     'kix01': 0.1,  # virtual site


### PR DESCRIPTION
We are experimenting with converting gru and hnd metros to all cloud. The first step is adding more virtual capacity and giving the virtual sites in these metros normal probability.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/269)
<!-- Reviewable:end -->
