### PR TITLE
Configures mlab-ns to use new format locations-physical

### DIFF
--- a/server/app.yaml.mlab-ns
+++ b/server/app.yaml.mlab-ns
@@ -58,7 +58,7 @@ env_variables:
   PROJECT: "mlab-ns"
   MACHINE_REGEX: "^mlab[1-3]$"
   SITE_REGEX: "^[a-z]{3}[0-9c]{2}$"
-  LOCATIONS_URL: "https://siteinfo.mlab-oti.measurementlab.net/v1/sites/locations.json"
+  LOCATIONS_URL: "https://siteinfo.mlab-oti.measurementlab.net/v2/sites/locations-physical.json"
   HOSTNAMES_URL: "https://siteinfo.mlab-oti.measurementlab.net/v2/sites/hostnames.json"
 
 inbound_services:

--- a/server/app.yaml.mlab-sandbox
+++ b/server/app.yaml.mlab-sandbox
@@ -58,7 +58,7 @@ env_variables:
   PROJECT: "mlab-sandbox"
   MACHINE_REGEX: "^mlab[1-4]$"
   SITE_REGEX: "^[a-z]{3}[0-9]t$"
-  LOCATIONS_URL: "https://siteinfo.mlab-sandbox.measurementlab.net/v1/sites/locations.json"
+  LOCATIONS_URL: "https://siteinfo.mlab-sandbox.measurementlab.net/v2/sites/locations-physical.json"
   HOSTNAMES_URL: "https://siteinfo.mlab-sandbox.measurementlab.net/v2/sites/hostnames.json"
 
 inbound_services:

--- a/server/app.yaml.mlab-staging
+++ b/server/app.yaml.mlab-staging
@@ -58,7 +58,7 @@ env_variables:
   PROJECT: "mlab-staging"
   MACHINE_REGEX: "^mlab4$"
   SITE_REGEX: "^[a-z]{3}[0-9c]{2}$"
-  LOCATIONS_URL: "https://siteinfo.mlab-staging.measurementlab.net/v1/sites/locations.json"
+  LOCATIONS_URL: "https://siteinfo.mlab-staging.measurementlab.net/v2/sites/locations-physical.json"
   HOSTNAMES_URL: "https://siteinfo.mlab-staging.measurementlab.net/v2/sites/hostnames.json"
 
 inbound_services:


### PR DESCRIPTION
Now that the Locate v2 is serving 100% of locate requests natively, mlab-ns is deprecated. Since ndt5-plain does not support any sort of admission controls, and many older ndt5 integrations query mlab-ns directly, we do not want to cloud sites to serve these ndt4-plain tests, as it is open for abuse, which could take down a VM or generate excessive egress traffic cost by abusing the server. This commit causes mlab-ns to only ingest physical sites by pointing it at a new siteinfo format that only includes physical sites.

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/m-lab/mlab-ns/270)
<!-- Reviewable:end -->
